### PR TITLE
Remove reference to the old dev SPARQL endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !/log/.keep
 /tmp
 .byebug_history
+public/assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.0.7 - 2019-12-16
+
+- Update qonsole-rails to (hopefully) reduce Sentry noise due to
+  path issues with error pages.
+
 ## 1.0.6 - 2019-12-10
 
 - Remove a reference to an old, now obsolete, dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.0.6 - 2019-12-10
+
+- Remove a reference to an old, now obsolete, dev
+  server as a target endpoint for Qonsole
+
 ## 1.0.5 - 2019-12-09
 
 - Pull in updated `qonsole-rails` to resolve Sentry warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.1.0 - 2019-12-17
+
+- Changed minor version number as we've switched to using a
+  separate Sentry project for this app.
+
 ## 1.0.7 - 2019-12-16
 
 - Update qonsole-rails to (hopefully) reduce Sentry noise due to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GIT
 
 GIT
   remote: https://github.com/epimorphics/qonsole-rails
-  revision: d6d1a6793319edfb6a1d3f8220b296e315f5bd65
+  revision: 8ca878ea01bd20638863ca1b842e3a0de0376327
   specs:
-    qonsole-rails (0.5.6)
+    qonsole-rails (0.5.7)
       codemirror-rails (~> 5.11)
       faraday (~> 0.17.0)
       faraday_middleware (~> 0.13.1)
@@ -77,13 +77,13 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    autoprefixer-rails (9.7.1)
+    autoprefixer-rails (9.7.3)
       execjs
     bindex (0.8.1)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     codemirror-rails (5.16.0)
       railties (>= 3.0, < 6.0)
@@ -138,7 +138,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    lodash-rails (4.17.14)
+    lodash-rails (4.17.15)
       railties (>= 3.1)
     loofah (2.4.0)
       crass (~> 1.0.2)
@@ -220,7 +220,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     temple (0.8.2)
-    thor (0.20.3)
+    thor (1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/epimorphics/qonsole-rails
-  revision: 8ca878ea01bd20638863ca1b842e3a0de0376327
+  revision: 70cead3804fb36956bcf400997028551024fda6a
   specs:
     qonsole-rails (0.5.7)
       codemirror-rails (~> 5.11)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 0
-  REVISION = 6
+  REVISION = 7
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 0
-  REVISION = 5
+  REVISION = 6
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,7 +2,7 @@
 
 module Version
   MAJOR = 1
-  MINOR = 0
-  REVISION = 7
+  MINOR = 1
+  REVISION = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,5 +76,5 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.relative_url_root = '/app/root'
+  config.relative_url_root = ENV['RELATIVE_URL_ROOT'] || '/app/root'
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,9 @@
 # frozen-string-literal: true
 
 Raven.configure do |config|
-  config.dsn = 'https://1150348b449a444bb3ac47ddd82b37c4:5fd368489fe44c0f83f1f2e5df10a7ef@sentry.io/251669'
+  config.dsn = 'https://0296b9563a944ef4bb6e41ffdc3fe4d2@sentry.io/1859729'
   config.current_environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
   config.environments = %w[production test]
   config.release = Version::VERSION
-  config.tags = { app: 'lr-landing' }
+  config.tags = { app: 'lr-dgu-landing' }
 end

--- a/config/qonsole.json
+++ b/config/qonsole.json
@@ -1,11 +1,9 @@
 {
   "endpoints": {
-    "default": "/landregistry/query",
-    "dev": "http://lr-pres-dev-c.epimorphics.net/landregistry/query"
+    "default": "/landregistry/query"
   },
   "alias": {
-    "default": null,
-    "dev": null
+    "default": null
   },
   "prefixes": {
     "rdf":      "http://www.w3.org/1999/02/22-rdf-syntax-ns#",

--- a/public/400.html
+++ b/public/400.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <title>
-      Land Registry Open Data &ndash; page not found
+      Land Registry Open Data &ndash; application error
     </title>
     <link rel="stylesheet" href="/stylesheets/landing.css" type="text/css">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" type="text/css">


### PR DESCRIPTION
To address #18, we have removed a reference to the old (no longer
operating) dev server `lr-pres-dev-c` as possible endpoint for the
Qonsole form.

@bwmcbride An updated version has been deployed to the dev server. It should show version `1.0.6` in the footer.