### PR TITLE
Add skip-to-main-content link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.3.1 - 2020-09-22 (Ian)
+
+- added skip-to-main-content link
+
 ## 1.3.0 - 2020-09-20 (Ian)
 
 - WCAG conformance updates, including updating to the upstream

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/epimorphics/lr_common_styles
-  revision: 9ed1936bf3ece3aadc2d3a80ae8bf4961407fdd2
+  revision: 3f14efcc2d6c806b77b5e1c91fa567fe3aa6e94d
   specs:
-    lr_common_styles (1.5.0)
+    lr_common_styles (1.6.0)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 3
-  REVISION = 0
+  REVISION = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end


### PR DESCRIPTION
Support keyboard navigation by adding a skip-to-main content link
