### PR TITLE
Enable the display of Welsh language in all envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.5.1 - 2021-01-20
+
+- (Ian) Welsh-language mode enabled in all deployment environments
+
 ## 1.5.0 - 2020-10-30 (Ian)
 
 - add Welsh translation of accessibility statement

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 5
-  REVISION = 0
+  REVISION = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,5 +81,5 @@ Rails.application.configure do
   config.accessibility_document_path = '/accessibility'
 
   # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = ENV['DEPLOYMENT_ENVIRONMENT'] == 'dev'
+  config.welsh_language_enabled = true
 end


### PR DESCRIPTION
Allow all deployment environments, including production, to display the Welsh
language affordances
