### PR TITLE
Add temporary flash message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -261,6 +263,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-17
+  x86_64-linux
 
 DEPENDENCIES
   byebug
@@ -280,4 +283,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.2.21
+   2.2.31

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -2,6 +2,17 @@
   .col-md-12
     %h1.heading-large
       Open Data
+
+    %p.bg-warning.text-warning{ style: "padding: 15px;" }
+      %strong
+        Please note:
+      we are experiencing some technical difficulties, and this service
+      may work slowly or report query timeouts. We are working
+      on fixing this as quickly as possible. We apologise for any
+      inconvenience that this may cause.
+      %small.pull-right.text-muted
+        19 Nov 2021
+
     %p
       HM Land Registry publishes the following public datasets on GOV.UK
       as part of our commitment to the Government’s priorities


### PR DESCRIPTION
Shows a flash message to warn users of ongoing slow-queries problem
