### PR TITLE
Text change in PPD documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.5.7 - 2021-12-01
+
+- (Joseph) Copy change in PPD documentation
+
 ## 1.5.6 - 2021-09-28
 
 - (Mairead) Updating copy change and broken link

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 5
-  REVISION = 6
+  REVISION = 7
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/views/doc/ppd.html.haml
+++ b/app/views/doc/ppd.html.haml
@@ -84,7 +84,7 @@
   %li The date of the transaction
   %li Information about the property
 %p
-  A standard PPD transaction concerns a single residential property sold for full market value to private individual.
+  A standard PPD transaction concerns a single residential property sold for value to private individual.
   An additional PPD transaction concerns repossessions, buy-to-lets and transfers of property sold to non-private individuals.
 %p
   The conversion process used takes these items and generates a number of ‘triples’ that are uploaded to a triple store that’s made available using a cloud based triple store. Descriptions of linked data formats are widely described in various web resources and are not covered here, HM Land Registry generate SPARQL update (<code>.ru</code>) files each month and these are described below.


### PR DESCRIPTION
Updates PPD documentation by substituting 'value' for 'full market value'.

Addresses epimorphics/hmlr-linked-data#59
