### PR TITLE
Ensure log output is in JSON format

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,28 @@ Bundler.require(*Rails.groups)
 
 require 'qonsole_rails'
 
+# Monkey-patch the bit of Rails that emits the start-up log message, so that it
+# is written out in JSON format that our combined logging service can handle
+# This versio is Rails 5.x specific. A different pattern is needed for Rails 6
+# applications.
+module Rails
+  # :nodoc:
+  class Server
+    # :nodoc:
+    def print_boot_information
+      url = "on #{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
+
+      msg = {
+        level: 'INFO',
+        ts: DateTime.now.rfc3339(3),
+        message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+      }
+
+      puts(msg.to_json) # rubocop:disable Rails/Output
+    end
+  end
+end
+
 module LrLanding
   # :nodoc:
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ require 'qonsole_rails'
 
 # Monkey-patch the bit of Rails that emits the start-up log message, so that it
 # is written out in JSON format that our combined logging service can handle
-# This versio is Rails 5.x specific. A different pattern is needed for Rails 6
+# This version is Rails 5.x specific. A different pattern is needed for Rails 6
 # applications.
 module Rails
   # :nodoc:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,10 @@ Rails.application.configure do
 
   config.assets.quiet = true
 
+  config.log_tags = %i[subdomain request_id request_method]
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,15 +46,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.log_tags = %i[subdomain request_id request_method]
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,10 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.log_tags = %i[subdomain request_id request_method]
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
+threads min_threads_count, max_threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch('PORT', 3000)
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch('RAILS_ENV', 'development')
+
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+# Use a custom log formatter to emit Puma log messages in a JSON format
+log_formatter do |str|
+  {
+    level: 'INFO',
+    ts: DateTime.now.rfc3339(3),
+    message: str
+  }.to_json
+end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ fi
 
 if [ -z "API_SERVICE_URL" ]
 then
-  echo "{'ts': '`date -Iseconds`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+  echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo "{'ts': '`date -Iseconds`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]


### PR DESCRIPTION
epimorphics/hmlr-linked-data#87

Ensure that all log output from the landing page app is written in JSON
format.

- use `json-rails-logger` as the log formatter
- ensure Rails and Puma startup messages in JSON
