### PR TITLE
Add the default Prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,5 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
 end
+
+gem "prometheus-client", "~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,4 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'lr_common_styles'
 end
 
-gem "prometheus-client", "~> 4.0"
+gem 'prometheus-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    prometheus-client (4.0.0)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -288,6 +289,7 @@ DEPENDENCIES
   jquery-rails
   json_rails_logger!
   lr_common_styles!
+  prometheus-client (~> 4.0)
   puma
   qonsole-rails!
   rails (~> 5.2.4)

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,13 @@
 
 # This file is used by Rack-based servers to start the application.
 
+require_relative 'config/environment'
+
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 require ::File.expand_path('config/environment', __dir__)
 run Rails.application


### PR DESCRIPTION
This commit adds the basic (i.e. built-in to the the Ruby Prometheus client)
set of metrics to the `lr-landing` application.

Since `lr-landing` is a very simple application, I propose to keep the
code clean and just stick to this core set of metrics.

@andrew-pickin-epi: are you OK with this? Since landing does not interact
an API, the only other metric I could add would be memory usage, but most 
likely won't be very informative for such a simple app as this.
