### PR TITLE
Expect the Sentry DSN to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ of the application:
 | -------------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
 | `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/root`                                      |
 | `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`                          |
+| `SENTRY_API_KEY`           | The Sentry DSN client key for the `lr-dgu-landing` Sentry app        |                                                  |

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,11 @@
 # frozen-string-literal: true
 
-Sentry.init do |config|
-  config.dsn = 'https://0296b9563a944ef4bb6e41ffdc3fe4d2@sentry.io/1859729'
-  config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
-  config.enabled_environments = %w[production test]
-  config.release = Version::VERSION
-  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+if ENV['SENTRY_API_KEY']
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_API_KEY']
+    config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+    config.enabled_environments = %w[production test]
+    config.release = Version::VERSION
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
+  end
 end


### PR DESCRIPTION
The Sentry API key should be passed in via the environment, and not
embedded in the code.
