### PR TITLE
Add static site content

### DIFF
--- a/public/qos-restriction.txt
+++ b/public/qos-restriction.txt
@@ -1,0 +1,26 @@
+request restricted due to resource limitations
+
+Resource limitations may vary from time to time depending on load and other conditions.
+You are unlikely to encounter a resource limitation if you use the data API for data accesss
+from programs and  issue at most two simultaneous data requests.  Data requests include 
+SPARQL queries, data API requests.
+
+Resource limitations for APIs intended to be used by the user interface are more restrictive
+than resource limitations on the data API and SPARQL queries.  If you are trying to retrieve
+data you are likely better off using the data API or SPARQL rather than scraping the UI pages
+or using UI specific APIs.
+
+See: 
+  http://landregistry.data.gov.uk/app/doc/ukhpi
+  http://landregistry.data.gov.uk/app/root/doc/ppd
+
+If the computer issuing the data requests is behind a proxy or is part of a shared serverless
+infrastructure, requests from other users behind the same proxy or using the same 
+infrastructure may count towards your resource usage.
+
+Please contact HM Land Registry if you believe you received this response in error or have
+any questions or would like help using the data.
+
+Email data.services@landregistry.gov.uk 
+Telephone 0300 006 0478
+Web: https://help.landregistry.gov.uk/app/contactus_general/

--- a/public/qos-restriction.txt
+++ b/public/qos-restriction.txt
@@ -11,8 +11,8 @@ data you are likely better off using the data API or SPARQL rather than scraping
 or using UI specific APIs.
 
 See: 
-  http://landregistry.data.gov.uk/app/doc/ukhpi
-  http://landregistry.data.gov.uk/app/root/doc/ppd
+  https://landregistry.data.gov.uk/app/doc/ukhpi
+  https://landregistry.data.gov.uk/app/root/doc/ppd
 
 If the computer issuing the data requests is behind a proxy or is part of a shared serverless
 infrastructure, requests from other users behind the same proxy or using the same 

--- a/public/qos-ui-api-restriction.txt
+++ b/public/qos-ui-api-restriction.txt
@@ -7,11 +7,11 @@ If you wish to access HM Land Registry data in bulk, please download the bulk da
 
 If you wish to make adhoc queries of the HM Land Registry data, please use the documented data access APIs, e.g.
 
-  http://landregistry.data.gov.uk/app/root/doc/ppd
+  https://landregistry.data.gov.uk/app/root/doc/ppd
   
 or the SPARQL endpoint at:
 
-  http://landregistry.data.gov.uk/landregistry/query
+  https://landregistry.data.gov.uk/landregistry/query
   
 The data APIs and SPARQL endpoint are not intended for bulk data access and their are restrictions on access rates.
 

--- a/public/qos-ui-api-restriction.txt
+++ b/public/qos-ui-api-restriction.txt
@@ -1,0 +1,23 @@
+If you are seeing this it is because you have been programatically accessing a URL that
+it is intended for use only by HM Land Registry applications.
+
+If you wish to access HM Land Registry data in bulk, please download the bulk data file, e.g. at
+
+  https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads  
+
+If you wish to make adhoc queries of the HM Land Registry data, please use the documented data access APIs, e.g.
+
+  http://landregistry.data.gov.uk/app/root/doc/ppd
+  
+or the SPARQL endpoint at:
+
+  http://landregistry.data.gov.uk/landregistry/query
+  
+The data APIs and SPARQL endpoint are not intended for bulk data access and their are restrictions on access rates.
+
+If you believe your are seeing this message in error, or wish further help to make use of
+HM Land Registry data, please contact:
+
+Email data.services@landregistry.gov.uk 
+Telephone 0300 006 0478
+Web: https://help.landregistry.gov.uk/app/contactus_general/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,13 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+Disallow: /def
+Disallow: /doc
+Disallow: /data
+Disallow: /sparql
+Disallow: /id
+Disallow: /so
+Disallow: /anything
+Disallow: /thing
+Disallow: /app/ppd/search?
+Allow: /
+


### PR DESCRIPTION
The site needs to serve some static files for robot management and text to link to from QOS rejections.
Suggest these are served from the landing app so this PR adds the current production version of those files to the public assets.

Addresses: epimorphics/hmlr-ansible-deployment#109

