### PR TITLE
Collective lift and shift updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@
 CHANGELOG.md
 README.md
 log/
+
+public/assets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
-## 1.6.1 - 2023-03-15
+## 1.7.0 - 2023-03-15
 
 - (Jon) Updated the README to improve the clarity of the instructions for
   running the application locally, as well as releasing a new version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Qonsole
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if
   provided; otherwise no SUFFIX is included in the version number.
 - (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
-  `APPLICATION_PATH` to be more clear on it's use in the `entrypoint.sh` code.
+  `APPLICATION_ROOT` to be more clear on it's use in the `entrypoint.sh` code.
 
 ## 1.6.0 - 2022-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Qonsole
   current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if
   provided; otherwise no SUFFIX is included in the version number.
+- (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
+  `APPLICATION_PATH` to be more clear on it's use in the `entrypoint.sh` code.
 
 ## 1.6.0 - 2022-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
-## 1.6.1 - 2023-01
+## 1.6.1 - 2023-03-15
 
+- (Jon) Updated the README to improve the clarity of the instructions for
+  running the application locally, as well as releasing a new version.
+- (Jon) Updated and improved the build files for the new infrastructure use.
 - (Jon) Minor text changes to the `Gemfile` to include instructions for running
   Epimorphics specific gems locally during the development of those gems.
 - (Jon) Updated the production `json_rails_logger` gem version to be at least the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ Qonsole
 - (Jon) Minor text changes to the `Gemfile` to include instructions for running
   Epimorphics specific gems locally during the development of those gems.
 - (Jon) Updated the production `json_rails_logger` gem version to be at least the
-  current version `~>0.3.4` (this is to cover out of sync release versions)
+  current version `~>0.3.5` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
-  current version `~>1.9.0` (this is to cover out of sync release versions)
+  current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if
   provided; otherwise no SUFFIX is included in the version number.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This app presents the landing page experience for
 landregistry.data.gov.uk, including the SPARQL
 Qonsole
 
+## 1.6.1 - 2023-01
+
+- (Jon) Minor text changes to the `Gemfile` to include instructions for running
+  Epimorphics specific gems locally during the development of those gems.
+- (Jon) Updated the production `json_rails_logger` gem version to be at least the
+  current version `~>0.3.4` (this is to cover out of sync release versions)
+- (Jon) Updated the production `lr_common_styles` gem version to be at least the
+  current version `~>1.9.0` (this is to cover out of sync release versions)
+- (Jon) Refactored the version cadence creation to include a SUFFIX value if
+  provided; otherwise no SUFFIX is included in the version number.
+
 ## 1.6.0 - 2022-04-07
 
 - (Ian) Adopt all of the current Epimorphics best-practice deployment patterns,

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,9 @@ gem 'jbuilder', '~> 2.0'
 
 gem 'haml-rails', '~> 2.0.0'
 gem 'http_accept_language'
+gem 'prometheus-client', '~> 4.0'
 gem 'puma'
 gem 'sentry-rails', '~> 5.2'
-gem 'prometheus-client', '~> 4.0'
-
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -33,9 +32,11 @@ group :development do
   gem 'web-console'
 end
 
+# rubocop:disable Layout/LineLength
 # TODO: For running the app locally for testing you can set this to your local path
 # gem 'json_rails_logger', '~> 0.3.4', path: '~/Epimorphics/shared/json-rails-logger/'
 # gem 'lr_common_styles', '~> 1.9.0', path: '~/Epimorphics/clients/land-registry/projects/lr-common-styles/'
+# rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do

--- a/Gemfile
+++ b/Gemfile
@@ -33,13 +33,16 @@ group :development do
 end
 
 # rubocop:disable Layout/LineLength
+gem 'qonsole-rails', git: 'https://github.com/epimorphics/qonsole-rails'
+# gem 'qonsole-rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
+
 # TODO: For running the app locally for testing you can set this to your local path
-# gem 'json_rails_logger', '~> 0.3.4', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', '~> 1.9.0', path: '~/Epimorphics/clients/land-registry/projects/lr-common-styles/'
+# gem 'json_rails_logger', '~> 0.3.5', path: '~/Epimorphics/shared/json-rails-logger/'
+# gem 'lr_common_styles', '~> 1.9.1', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
 # rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
-  gem 'json_rails_logger', '~> 0.3.4'
-  gem 'lr_common_styles', '~> 1.9.0'
+  gem 'json_rails_logger', '~> 0.3.5'
+  gem 'lr_common_styles', '~> 1.9.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'haml-rails', '~> 2.0.0'
 gem 'http_accept_language'
 gem 'puma'
 gem 'sentry-rails', '~> 5.2'
+gem 'prometheus-client', '~> 4.0'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -31,12 +33,12 @@ group :development do
   gem 'web-console'
 end
 
-gem 'qonsole-rails', git: 'https://github.com/epimorphics/qonsole-rails'
-# gem 'qonsole-rails', path: '/home/ian/projects/epimorphics/qonsole-rails'
+# TODO: For running the app locally for testing you can set this to your local path
+# gem 'json_rails_logger', '~> 0.3.4', path: '~/Epimorphics/shared/json-rails-logger/'
+# gem 'lr_common_styles', '~> 1.9.0', path: '~/Epimorphics/clients/land-registry/projects/lr-common-styles/'
 
+# TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
-  gem 'json_rails_logger'
-  gem 'lr_common_styles'
+  gem 'json_rails_logger', '~> 0.3.4'
+  gem 'lr_common_styles', '~> 1.9.0'
 end
-
-gem 'prometheus-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/epimorphics/qonsole-rails
-  revision: b31b5d2c4489ebda258081d7da1db05cffb1011a
+  revision: 40c646990549c4e8697cf177d6bc47a6ebf09b32
   specs:
     qonsole-rails (0.6.1)
       codemirror-rails (~> 5.11)
@@ -61,7 +61,7 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.2.0)
+    autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
     bindex (0.8.1)
     bootstrap-sass (3.4.1)
@@ -76,7 +76,7 @@ GEM
     erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.8.1)
-    faraday (0.17.5)
+    faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.5)
       faraday
@@ -125,7 +125,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.6.1)
+    json (2.6.3)
     lodash-rails (4.17.21)
       railties (>= 3.1)
     lograge (0.12.0)
@@ -145,7 +145,7 @@ GEM
     modernizr-rails (2.7.1)
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
-    multipart-post (2.1.1)
+    multipart-post (2.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
@@ -259,11 +259,11 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    json_rails_logger (0.3.4)
+    json_rails_logger (0.3.5.3)
       json
       lograge
       railties
-    lr_common_styles (1.9.0)
+    lr_common_styles (1.9.1.1)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -279,6 +279,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-17
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -287,8 +288,8 @@ DEPENDENCIES
   http_accept_language
   jbuilder (~> 2.0)
   jquery-rails
-  json_rails_logger!
-  lr_common_styles!
+  json_rails_logger (~> 0.3.5)!
+  lr_common_styles (~> 1.9.1)!
   prometheus-client (~> 4.0)
   puma
   qonsole-rails!
@@ -301,4 +302,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.2.32
+   2.4.4

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ALPINE_VERSION?=3.12
 AWS_REGION?=eu-west-1
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
 ECR?=${ACCOUNT}.dkr.ecr.eu-west-1.amazonaws.com
-GRP_OWNER?=epimorphics
+GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 RUBY_VERSION?=$(shell cat .ruby-version)
@@ -29,7 +29,7 @@ BUNDLE_CFG=${HOME}/.bundle/config
 all: image
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
-	@./bin/bundle config set --local rubygems.pkg.github.com ${GRP_OWNER}:`cat ${GITHUB_TOKEN}`
+	@./bin/bundle config set --local rubygems.pkg.github.com ${GPR_OWNER}:`cat ${GITHUB_TOKEN}`
 
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
@@ -51,12 +51,11 @@ image: auth lint test
 		--build-arg RUBY_VERSION=${RUBY_VERSION} \
 		--build-arg BUNDLER_VERSION=${BUNDLER_VERSION} \
 		--build-arg VERSION=${VERSION} \
-		--build-arg build_date=`date -Iseconds` \
 		--build-arg git_branch=${BRANCH} \
 		--build-arg git_commit_hash=${COMMIT} \
 		--build-arg github_run_number=${GITHUB_RUN_NUMBER} \
 		--build-arg image_name=${NAME} \
-	  --tag ${REPO}:${TAG} \
+		--tag ${REPO}:${TAG} \
 		.
 	@echo Done.
 
@@ -72,9 +71,10 @@ realclean: clean
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
 run:
-	@-docker stop lr_landing
-	@-docker rm lr_landing && sleep 20
-	@docker run -p 3000:3000 --rm --name lr_landing ${REPO}:${TAG}
+	@echo "Stopping lr_landing ..."
+	@-docker stop lr_landing && sleep 10
+	@echo "Starting lr_landing ..."
+	@docker run -e APPLICATION_ROOT=${APPLICATION_ROOT} -e API_SERVICE_URL=${API_SERVICE_URL} --add-host host.docker.internal:host-gateway -p 3000:3000 --rm --name lr_landing ${REPO}:${TAG}
 
 tag:
 	@echo ${TAG}
@@ -89,7 +89,7 @@ vars:
 	@echo "AWS_REGION = ${AWS_REGION}"
 	@echo "BUNDLER_VERSION = ${BUNDLER_VERSION}"
 	@echo "ECR = ${ECR}"
-	@echo "GRP_OWNER = ${GRP_OWNER}"
+	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
 	@echo "STAGE = ${STAGE}"

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Begin by cloning [the Github
 repo](https://github.com/epimorphics/lr-landing) and installing the dependencies:
 
 ```sh
-git clone git@github.com:epimorphics/lr-landing.git
-cd lr-landing
+git clone git@github.com:epimorphics/lr-landing.git &&
+cd lr-landing &&
 bundle install
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ writing:
 ### `entrypoint.sh`
 
 - The Rails Framework requires certain values to be set as a Global environment
-  variable when starting. To ensure the `RAILS_RELATIVE_URL_ROOT` is only set
+  variable when starting. To ensure the `APPLICATION_PATH` is only set
   in one place per application we have added this to the Entrypoint file along
   with the `SCRIPT_NAME`.
 - The Rails secret is also created here.
@@ -85,8 +85,8 @@ writing:
 We use a number of environment variables to determine the runtime behaviour
 of the application:
 
-| name                       | description                                                          | typical value                                    |
-| -------------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/root`                                      |
-| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`                          |
-| `SENTRY_API_KEY`           | The Sentry DSN client key for the `lr-dgu-landing` Sentry app        |                                                  |
+| name                       | description                                                          | typical value           |
+| -------------------------- | -------------------------------------------------------------------- | ----------------------- |
+| `APPLICATION_PATH`         | The path from the server root to the application                     | `/app/root`             |
+| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080` |
+| `SENTRY_API_KEY`           | The Sentry DSN client key for the `lr-dgu-landing` Sentry app        |                         |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ provides links to the various open data services (Price Paid Data Explorer,
 Standard Reports and UK Housing Price Index), and hosts the qonsole app, which
 allows users to run SPARQL queries against the linked-data dataset.
 
-Please see the other repos in the [HM Land Registry Open Data](http://landregistry.data.gov.uk)
-family for more details:
+Please see the other repositories in the [HM Land Registry Open Data](http://landregistry.data.gov.uk)
+project for more details:
 
 - [Price Paid Data Explorer](https://github.com/epimorphics/ppd-explorer)
 - [Standard Reports UI](https://github.com/epimorphics/standard-reports-ui)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,16 @@ With the proxy and Docker container running you can access the application as
 
 ### Code standards
 
-Rubocop should return zero errors or warnings
+Rubocop should return zero errors or warnings:
+
+```sh
+$ rubocop
+
+Inspecting 30 files
+..............................
+
+30 files inspected, no offenses detected
+```
 
 ### Running the tests
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,80 @@
 # HMLR linked-data applications landing site
 
-This repo provides the landing page experience for visitors
-to [landregistry.data.gov.uk](http://landregistry.data.gov.uk).
-The landing page provides links to the various open data services
-(PPD, standard reports and UKHPI), and hosts the qonsole app, which
+This repo provides the landing page experience for visitors to
+[landregistry.data.gov.uk](http://landregistry.data.gov.uk). The landing page
+provides links to the various open data services (Price Paid Data Explorer,
+Standard Reports and UK Housing Price Index), and hosts the qonsole app, which
 allows users to run SPARQL queries against the linked-data dataset.
+
+Please see the other repos in the [HM Land Registry Open Data](http://landregistry.data.gov.uk)
+family for more details:
+
+- [Price Paid Data Explorer](https://github.com/epimorphics/ppd-explorer)
+- [Standard Reports UI](https://github.com/epimorphics/standard-reports-ui)
+- [UK Housing Price Index](https://github.com/epimorphics/ukhpi)
+- [Qonsole](https://github.com/epimorphics/qonsole-rails)
 
 ## Developer notes
 
 ### Updating the code
 
-This is a pretty standard, and quite small, Rails app. Clone
-[the Github repo](https://github.com/epimorphics/lr-landing)
-to start making changes.
+This is a pretty standard, and quite small, Rails app.
 
-Please keep the [changelog](CHANGELOG.md) up-to-date, and
-increment the `Version::VERSION` identifier in line with
-semver principles.
+Please keep the [changelog](CHANGELOG.md) up-to-date, and increment the
+[`/app/lib/version.rb`](https://github.com/epimorphics/lr-landing/app/lib/version.rb)
+identifier in line with semver principles.
+
+### Running the app locally in dev mode
+
+Begin by cloning [the Github
+repo](https://github.com/epimorphics/lr-landing) and installing the dependencies:
+
+```sh
+git clone git@github.com:epimorphics/lr-landing.git
+cd lr-landing
+bundle install
+```
+
+Start the app locally for development:
+
+```sh
+APPLICATION_ROOT=/ rails server
+```
+
+Visit [`localhost:3000`](http://localhost:3000/) to view the local instance.
+
+### Running the app locally as a Docker image
+
+It can be useful to run the compiled Docker image, that will be run by the
+production installation, locally yourself. While the Rails Framework requires
+certain values to be set as a Global environment variable when starting, the
+`API_SERVICE_URL` is only set in one place per application so we have added this
+to the Makefile file for convenience.
+
+To mimic running the application in a deployed state you can call:
+
+```sh
+make image
+```
+
+This will run through the assets precompilation, linting and testing before
+creating a Docker image, then you can run the image with the following command:
+
+```sh
+APPLICATION_ROOT=/ make run
+```
+
+N.B In the production environment, the app will be accessed via the URL path `/app/root`.
+When running the docker image locally for development, you may need to access the
+application via a proxy, otherwise, the paths for JS, CSS and image assets might
+not work.
+
+Please see the *[simple web proxy](https://github.com/epimorphics/simple-web-proxy)*
+repository for one simple way of handling this on a local develpment machine.
+
+With the proxy and Docker container running you can access the application as
+[`localhost:3001/app/root/`](http://localhost:3001/app/root/)
+(note the trailing path).
 
 ### Code standards
 
@@ -26,64 +84,64 @@ Rubocop should return zero errors or warnings
 
 There aren't very many tests as this is a very simple app.
 
-    rails -t
+```sh
+rails -t
+```
 
 ### Dependent gems
 
-As of 2022-04-04, most of the local (i.e. Epimorphics) gems that this project
-depends on are served via GitHub Package Registry (GPR). Specifically,
-`lr_common_styles` and `json-rails-logger`. However, `qonsole-rails` is **not**
-served via GPR at present, mostly because we are hoping to retire it in favour
-of a new implementation of Qonsole. Since `qonsole-rails` is a public repo,
-this dependency does not require us to lean on the old pattern of using an ssh
-key to serve private gems directly from a GitHub repo.
+Most of the local (i.e. Epimorphics) gems that this project depends on are served
+via GitHub Package Registry (GPR). Specifically, `lr_common_styles` and `json-rails-logger`.
 
-Accessing gems from GPR will require a personal access token PAT. To store this
-locally, use `make auth`. To create a PAT, see [the Epimorphics
-wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access).
+However, `qonsole-rails` is __not__ served via GPR at present, mostly because we
+are hoping to retire it in favour of a new implementation of Qonsole. Since
+`qonsole-rails` is a public repo, this dependency does not require us to lean on
+the old pattern of using an ssh key to serve private gems directly from a
+GitHub repo.
 
-### Pre-flight testing
+Accessing gems from GPR will require a personal access token (PAT). To store this
+locally, use `make auth` to set your GitHub Token using the PAT.
 
-To mimic running the application in a deployed state you can run `make image`
-and this will run through the assets precompilation, linting and testing before
-creating a Docker image. To view the Docker container you can run `make run`
-
-Note that in the production environment, the app will be accessed via the URL
-path `/app/root`. When running the docker image locally, you will need to
-access the application via a proxy, otherwise, the paths for JS, CSS and image
-assets will not work. Please see the [simple web
-proxy](https://github.com/epimorphics/simple-web-proxy) for one simple way of
-handling this on a local dev machine.
+To create a PAT, see [the Epimorphics wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access).
 
 ## Issues
 
-Please add issues to the [shared issues list](https://github.com/epimorphics/hmlr-linked-data/issues)
+Please add issues to the [shared issues
+list](https://github.com/epimorphics/hmlr-linked-data/issues)
 
 ## Deployment
 
-The detailed deployment mapping is decscribed in `deployment.yml`. At the time of
-writing:
+The detailed deployment mapping is decscribed in `deployment.yml`. At the time
+of writing, using the new infrastructure, the deployment process is as follows:
 
-- any commit tagged with `vNNN`, e.g: `v1.2.7` will be deployed to production
-- any commit on the `dev-infrastructure` branch will deploy the dev server in
-  using the new infrastructure
+- commits to the `dev-infrastructure` branch will deploy the dev server
+- commits to the `preprod` branch will deploy the pre-production server
+- any commit on the `prod` branch will deploy the production server as a new
+  release
+
+If the commit is a "new" release, the deployment should be tagged with the same
+version number, e.g. `1.2.3`. as set in the `/app/lib/version.rb` and a short
+annotation summarising the updates should be included in the tag.
+
+Once the production deployment has been completed and verified, please create a
+release on the repository using the same latest version number. Utilise the
+`Generate release notes from commit log` option to create specific notes on the
+contained changes as well as the ability to diff agains the previous version.
 
 ### `entrypoint.sh`
 
-- The Rails Framework requires certain values to be set as a Global environment
-  variable when starting. To ensure the `APPLICATION_ROOT` is only set
-  in one place per application we have added this to the Entrypoint file along
-  with the `SCRIPT_NAME`.
-- The Rails secret is also created here.
 - There is a workaround to removing the PID lock of the Rails process in the
   event of the application crashing and not releasing the process.
-- We have to pass the `API_SERVICE_URL` so that it is available in the
-  `entrypoint.sh` or the application will throw an error and exit before starting
+- The Rails secret is created here.
+- We have to pass the `APPLICATION_ROOT` and, depending on the ivocation choice
+  also pass in the `API_SERVICE_URL`, so that they are available to the
+  `entrypoint.sh` otherwise the application will throw an error and exit before
+  starting.
 
-## Configuration environment variables
+#### Configuration environment variables
 
-We use a number of environment variables to determine the runtime behaviour
-of the application:
+We use a number of environment variables to determine the runtime behaviour of
+the application:
 
 | name                       | description                                                          | typical value           |
 | -------------------------- | -------------------------------------------------------------------- | ----------------------- |

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ provides links to the various open data services (Price Paid Data Explorer,
 Standard Reports and UK Housing Price Index), and hosts the qonsole app, which
 allows users to run SPARQL queries against the linked-data dataset.
 
-Please see the other repositories in the [HM Land Registry Open Data](http://landregistry.data.gov.uk)
+Please see the other repositories in the [HM Land Registry Open Data](https://github.com/epimorphics/hmlr-linked-data/)
 project for more details:
 
-- [Price Paid Data Explorer](https://github.com/epimorphics/ppd-explorer)
+- [HMLR Common Styles](https://github.com/epimorphics/lr_common_styles)
+- [PPD Explorer](https://github.com/epimorphics/ppd-explorer)
 - [Standard Reports UI](https://github.com/epimorphics/standard-reports-ui)
-- [UK Housing Price Index](https://github.com/epimorphics/ukhpi)
-- [Qonsole](https://github.com/epimorphics/qonsole-rails)
+- [UKHPI](https://github.com/epimorphics/ukhpi)
+- [Qonsole (Rails)](https://github.com/epimorphics/qonsole-rails)
 
 ## Developer notes
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ writing:
 ### `entrypoint.sh`
 
 - The Rails Framework requires certain values to be set as a Global environment
-  variable when starting. To ensure the `APPLICATION_PATH` is only set
+  variable when starting. To ensure the `APPLICATION_ROOT` is only set
   in one place per application we have added this to the Entrypoint file along
   with the `SCRIPT_NAME`.
 - The Rails secret is also created here.
@@ -87,6 +87,6 @@ of the application:
 
 | name                       | description                                                          | typical value           |
 | -------------------------- | -------------------------------------------------------------------- | ----------------------- |
-| `APPLICATION_PATH`         | The path from the server root to the application                     | `/app/root`             |
+| `APPLICATION_ROOT`         | The path from the server root to the application                     | `/app/root`             |
 | `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080` |
 | `SENTRY_API_KEY`           | The Sentry DSN client key for the `lr-dgu-landing` Sentry app        |                         |

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 6
-  REVISION = 0
-  VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
+  REVISION = 1
+  SUFFIX = nil
+  VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 1
-  MINOR = 6
-  REVISION = 1
+  MINOR = 7
+  REVISION = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Application Path can be specified in the entrypoint.sh script
+  # but falls back to a standard root value in development
+  config.relative_url_root = ENV.fetch('APPLICATION_PATH', '/')
+  # API location is not used on the landing page, but is required by all other apps
+
   config.accessibility_document_path = '/doc/accessibility'
   config.privacy_document_path = '/doc/privacy'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,9 +44,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Application Path can be specified in the entrypoint.sh script
+  # The application path can be specified in the entrypoint.sh script
   # but falls back to a standard root value in development
-  config.relative_url_root = ENV.fetch('APPLICATION_PATH', '/')
+  config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
   # API location is not used on the landing page, but is required by all other apps
 
   config.accessibility_document_path = '/doc/accessibility'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,11 +81,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
 
-  # Application Path should be specified in the entrypoint.sh file and therefore
+  # The application root should be specified in the entrypoint.sh file and therefore
   # in Production no fall back values are passed on the basis that missing
   # configuration options represent a category of bug, and in that case the
   # deployment should fail fast and noisily.
-  config.relative_url_root = ENV['APPLICATION_PATH']
+  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
   # API location is not used on the landing page, but is required by all other apps
 
   config.accessibility_document_path = '/accessibility'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,17 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # * Set cache control headers for HMLR apps to be public and cacheable
+  # * Landing Page uses a time limit of 5 minutes (300 seconds)
+  # This will affect assets served from /app/assets
+  config.static_cache_control = "public, max-age=#{5.minutes.to_i}"
+
+  # This will affect assets in /public, e.g. webpacker assets.
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{5.minutes.to_i}",
+    'Expires' => 5.minutes.from_now.to_formatted_s(:rfc822)
+  }
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
@@ -70,9 +81,12 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
 
-  config.logger = JsonRailsLogger::Logger.new($stdout)
-
-  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || '/'
+  # Application Path should be specified in the entrypoint.sh file and therefore
+  # in Production no fall back values are passed on the basis that missing
+  # configuration options represent a category of bug, and in that case the
+  # deployment should fail fast and noisily.
+  config.relative_url_root = ENV['APPLICATION_PATH']
+  # API location is not used on the landing page, but is required by all other apps
 
   config.accessibility_document_path = '/accessibility'
   config.privacy_document_path = '/privacy'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,24 +11,25 @@ then
   export RAILS_ENV=production
 fi
 
-[ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+[ -z "$API_SERVICE_URL" ] && echo '{"ts": "'"$(date -u +%FT%T.%3NZ)"'", "level": "ERROR", "message": "You have not specified the env var API_SERVICE_URL"}' >&2
 
-[ -z "APPLICATION_ROOT" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_ROOT', 'level': 'ERROR'}}" >&2
+[ -z "$APPLICATION_ROOT" ] && echo '{"ts": "'"$(date -u +%FT%T.%3NZ)"'", "level": "ERROR", "message": "You have not specified the env var APPLICATION_ROOT"}' >&2
 
-if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_ROOT"]
+if [ -z "$API_SERVICE_URL" ] || [ -z "$APPLICATION_ROOT" ]
 then
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_ROOT ${APPLICATION_ROOT}', 'level': 'INFO'}}"
-
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
 then
-  export SECRET_KEY_BASE=`./bin/rails secret`
+  SECRET_KEY_BASE=$(./bin/rails secret)
+  export SECRET_KEY_BASE
 fi
 
 export RAILS_RELATIVE_URL_ROOT=${APPLICATION_ROOT:-'/app/root'}
 export SCRIPT_NAME=${APPLICATION_ROOT}
 
-exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0
+echo '{"ts": "'"$(date -u +%FT%T.%3NZ)"'", "level": "INFO", "message": "Starting LR Landing application with RAILS_ENV='"${RAILS_ENV}"'", "RAILS_RELATIVE_URL_ROOT"="'"${RAILS_RELATIVE_URL_ROOT}"'", "SCRIPT_NAME"="'"${SCRIPT_NAME}"'", "API_SERVICE_URL"="'"${API_SERVICE_URL}"'"}'
+
+exec ./bin/rails server -e "${RAILS_ENV}" -b 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,13 +11,16 @@ then
   export RAILS_ENV=production
 fi
 
-if [ -z "API_SERVICE_URL" ]
+[ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+
+[ -z "APPLICATION_PATH" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_PATH', 'level': 'ERROR'}}" >&2
+
+if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_PATH"]
 then
-  echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_PATH ${APPLICATION_PATH}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
@@ -25,7 +28,7 @@ then
   export SECRET_KEY_BASE=`./bin/rails secret`
 fi
 
-export RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT:-'/app/root'}
-export SCRIPT_NAME=${RAILS_RELATIVE_URL_ROOT}
+export APPLICATION_PATH=${APPLICATION_PATH:-'/app/root'}
+export SCRIPT_NAME=${APPLICATION_PATH}
 
 exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,14 +13,14 @@ fi
 
 [ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
 
-[ -z "APPLICATION_PATH" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_PATH', 'level': 'ERROR'}}" >&2
+[ -z "APPLICATION_ROOT" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_ROOT', 'level': 'ERROR'}}" >&2
 
-if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_PATH"]
+if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_ROOT"]
 then
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_PATH ${APPLICATION_PATH}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'LR-landing starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_ROOT ${APPLICATION_ROOT}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
@@ -28,7 +28,7 @@ then
   export SECRET_KEY_BASE=`./bin/rails secret`
 fi
 
-export APPLICATION_PATH=${APPLICATION_PATH:-'/app/root'}
-export SCRIPT_NAME=${APPLICATION_PATH}
+export RAILS_RELATIVE_URL_ROOT=${APPLICATION_ROOT:-'/app/root'}
+export SCRIPT_NAME=${APPLICATION_ROOT}
 
 exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0


### PR DESCRIPTION
This PR includes and resolves the following updates:

- Updated the README to improve the clarity of the instructions for
  running the application locally, as well as releasing a new version.
- Updated and improved the build files for the new infrastructure use.
- Minor text changes to the `Gemfile` to include instructions for running
  Epimorphics specific gems locally during the development of those gems.
- Updated the production `json_rails_logger` gem version to be at least the
  current version `~>0.3.5` (this is to cover out of sync release versions)
- Updated the production `lr_common_styles` gem version to be at least the
  current version `~>1.9.1` (this is to cover out of sync release versions)
- Refactored the version cadence creation to include a SUFFIX value if
  provided; otherwise no SUFFIX is included in the version number.
- Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
  `APPLICATION_ROOT` to be more clear on it's use in the `entrypoint.sh` code.