### PR TITLE
Set the `change_default_caching_policy` in the app `before_action`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+## 1.7.3.1 - 2023-07-11
+
+- (Jon) Updated the `app/controllers/application_controller.rb` to include the
+  `before_action` for the `change_default_caching_policy` method to ensure the
+  default `Cache-Control` header for all requests is set to 5 minutes (300 seconds).
+
 ## 1.7.3 - 2023-06-07
 
 - (Jon) Updated the `json_rails_logger` gem to the latest 1.0.1 patch release.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_locale
+  before_action :set_locale, :change_default_caching_policy
 
   private
 
@@ -20,4 +20,13 @@ class ApplicationController < ActionController::Base
 
     I18n.locale = user_locale if Rails.application.config.welsh_language_enabled
   end
+
+  # * Set cache control headers for HMLR apps to be public and cacheable
+  # * Landing Page uses a time limit of 5 minutes (300 seconds)
+  # Sets the default `Cache-Control` header for all requests,
+  # unless overridden in the action
+  def change_default_caching_policy
+    expires_in 5.minutes, public: true, must_revalidate: true if Rails.env.production?
+  end
+
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -4,6 +4,6 @@ module Version
   MAJOR = 1
   MINOR = 7
   REVISION = 3
-  SUFFIX = nil
+  SUFFIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
Using `before_action`s let's us "prepare" the data necessary before the action in the controller executes. In this case setting the cache headers to the desired length.

https://github.com/epimorphics/hmlr-linked-data/issues/114
