### PR TITLE
Updated lr_common_styles gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+## 1.7.5 - 2023-11-23
+
+- (Jon) Updated the `lr_common_styles` gem to the latest 1.9.3 patch release.
+
 ## 1.7.4 - 2023-11-23
 
 - (Jon) Updated the `lr_common_styles` gem to the latest 1.9.2 patch release.

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 # ! These "local" paths do not work with a docker image - use the repo instead
 # gem 'qonsole-rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
 # gem 'json_rails_logger', '~> 1.0.0', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', '~> 1.9.2', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
+# gem 'lr_common_styles', '~> 1.9.3', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
 # rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics github repo
@@ -46,5 +46,5 @@ gem 'qonsole-rails', git: 'https://github.com/epimorphics/qonsole-rails'
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger', '~> 1.0.0'
-  gem 'lr_common_styles', '~> 1.9.2'
+  gem 'lr_common_styles', '~> 1.9.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.2)
+    lr_common_styles (1.9.3)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -290,7 +290,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   json_rails_logger (~> 1.0.0)!
-  lr_common_styles (~> 1.9.2)!
+  lr_common_styles (~> 1.9.3)!
   prometheus-client (~> 4.0)
   puma
   qonsole-rails!

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  REVISION = 4
+  REVISION = 5
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR pulls in the changes required to update the application to use the latest version of the `lr_common_styles` gem