### PR TITLE
Handover redirections to proxy server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the old ppd doc routes to temporarily redirect to `app/doc/ppd`
-  as well as set the `ppd_doc_path` variable to point to the same reconfigured
-  route; alongside adding tests querying the new route to ensure the route is
-  valid and contains the expected content as well as tests to verify the old
-  routes redirect with 302 temporary status
+- (Jon) Reconfigured the `ppd_doc_path` variable to point to the `app/doc/ppd`
+  path; alongside adding tests querying the new route to ensure the route is
+  valid and contains the expected content. All redirections for any old routes
+  will now handled by the proxy server.
 
 ## 1.7.5 - 2023-11-23
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,6 @@ Rails.application.routes.draw do
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
   get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
-  get 'doc/ppd', to: redirect('/app/doc/ppd', status: 302)
-  get 'app/root/doc/ppd', to: redirect('app/doc/ppd', status: 302)
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'

--- a/test/integration/documentation_test.rb
+++ b/test/integration/documentation_test.rb
@@ -14,16 +14,6 @@ class DocumentationTest < ActionDispatch::IntegrationTest
     assert_equal(302, response.status)
   end
 
-  test 'older PPD doc link redirects with permanent 302 status' do
-    get '/doc/ppd'
-    assert_equal(302, response.status)
-  end
-
-  test 'old PPD doc link redirects with permanent 302 status' do
-    get '/app/root/doc/ppd'
-    assert_equal(302, response.status)
-  end
-
   test 'ppd_doc_path variable links correctly' do
     get ppd_doc_path
     assert_response :success


### PR DESCRIPTION
This PR removes code based redirections to allow proxy server to manage; also removes the redirection tests from the codebase.