### PR TITLE
Revised PPD Documentation Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the `ppd_doc_path` variable to point to the `app/doc/ppd`
-  path; alongside adding tests querying the new route to ensure the route is
-  valid and contains the expected content. All redirections for any old routes
-  will now handled by the proxy server.
+- (Jon) Reconfigured the `detailed documentation` links. both english and welsh
+  to point to the `app/doc/ppd` path; alongside adding tests querying the new
+  route to ensure the route is valid and contains the expected content. All
+  redirections for any old routes will now handled by the proxy server.
 
 ## 1.7.5 - 2023-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the `detailed documentation` links. both english and welsh
+- (Jon) Reconfigured the `detailed documentation` links, both english and welsh,
   to point to the `app/doc/ppd` path; alongside adding tests querying the new
   route to ensure the route is valid and contains the expected content. All
   redirections for any old routes will now handled by the proxy server.

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -91,8 +91,7 @@
     %h3.heading-small Gwybodaeth bellach
     %ul.list.list-bullet
       %li
-        = link_to( ppd_doc_path ) do
-          dogfennaeth fanwl
+        = link_to('dogfennaeth fanwl', '/app/doc/ppd')
         am y Data Pris a Dalwyd, y model data, a defnyddio’r data.
 
     %h2#standard-reports.heading-medium Lluniwr Adroddiad Safonol

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -91,8 +91,7 @@
     %h3.heading-small Further information
     %ul.list.list-bullet
       %li
-        = link_to( ppd_doc_path ) do
-          detailed documentation
+        = link_to('detailed documentation', '/app/doc/ppd')
         about the Price Paid Data, the data model, and using the data.
 
     %h2#standard-reports.heading-medium Standard Report Builder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get 'landing/hpi', to: 'landing#hpi'
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
-  get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
+  get 'doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'


### PR DESCRIPTION
Reconfigured the `detailed documentation` links, both english and welsh, to point to the `app/doc/ppd` path; alongside adding tests querying the new route to ensure the route is valid and contains the expected content. All redirections for any old routes will now handled by the proxy server.