### PR TITLE
Release Candidate - v1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the `ppd_doc_path` variable to point to the `app/doc/ppd`
-  path; alongside adding tests querying the new route to ensure the route is
-  valid and contains the expected content. All redirections for any old routes
-  will now handled by the proxy server.
+- (Jon) Reconfigured the `detailed documentation` links. both english and welsh
+  to point to the `app/doc/ppd` path; alongside adding tests querying the new
+  route to ensure the route is valid and contains the expected content. All
+  redirections for any old routes will now handled by the proxy server.
 
 ## 1.7.5 - 2023-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the old ppd doc routes to permanently redirect to `app/doc/ppd`
+- (Jon) Reconfigured the old ppd doc routes to temporarily redirect to `app/doc/ppd`
   as well as set the `ppd_doc_path` variable to point to the same reconfigured
   route; alongside adding tests querying the new route to ensure the route is
   valid and contains the expected content as well as tests to verify the old
-  routes redirect with 301 permanent status
+  routes redirect with 302 temporary status
 
 ## 1.7.5 - 2023-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the old ppd doc routes to temporarily redirect to `app/doc/ppd`
-  as well as set the `ppd_doc_path` variable to point to the same reconfigured
-  route; alongside adding tests querying the new route to ensure the route is
-  valid and contains the expected content as well as tests to verify the old
-  routes redirect with 302 temporary status
+- (Jon) Reconfigured the `ppd_doc_path` variable to point to the `app/doc/ppd`
+  path; alongside adding tests querying the new route to ensure the route is
+  valid and contains the expected content. All redirections for any old routes
+  will now handled by the proxy server.
 
 ## 1.7.5 - 2023-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+## 1.7.6 - 2024-03-12
+
+- (Jon) Reconfigured the old ppd doc routes to permanently redirect to `app/doc/ppd`
+  as well as set the `ppd_doc_path` variable to point to the same reconfigured
+  route; alongside adding tests querying the new route to ensure the route is
+  valid and contains the expected content as well as tests to verify the old
+  routes redirect with 301 permanent status
+
 ## 1.7.5 - 2023-11-23
 
 - (Jon) Updated the `lr_common_styles` gem to the latest 1.9.3 patch release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ including the SPARQL Qonsole
 
 ## 1.7.6 - 2024-03-12
 
-- (Jon) Reconfigured the `detailed documentation` links. both english and welsh
+- (Jon) Reconfigured the `detailed documentation` links, both english and welsh,
   to point to the `app/doc/ppd` path; alongside adding tests querying the new
   route to ensure the route is valid and contains the expected content. All
   redirections for any old routes will now handled by the proxy server.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update \
     nodejs \
     tzdata \
     && rm -rf /var/cache/apk/* \
-    && gem update --system \
+    && gem update --system 3.4.22 \
     && gem install bundler:$BUNDLER_VERSION \
     && bundle config --global frozen 1
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,5 +28,4 @@ class ApplicationController < ActionController::Base
   def change_default_caching_policy
     expires_in 5.minutes, public: true, must_revalidate: true if Rails.env.production?
   end
-
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  REVISION = 5
+  REVISION = 6
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -91,8 +91,7 @@
     %h3.heading-small Gwybodaeth bellach
     %ul.list.list-bullet
       %li
-        = link_to( ppd_doc_path ) do
-          dogfennaeth fanwl
+        = link_to('dogfennaeth fanwl', '/app/doc/ppd')
         am y Data Pris a Dalwyd, y model data, a defnyddio’r data.
 
     %h2#standard-reports.heading-medium Lluniwr Adroddiad Safonol

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -91,8 +91,7 @@
     %h3.heading-small Further information
     %ul.list.list-bullet
       %li
-        = link_to( ppd_doc_path ) do
-          detailed documentation
+        = link_to('detailed documentation', '/app/doc/ppd')
         about the Price Paid Data, the data model, and using the data.
 
     %h2#standard-reports.heading-medium Standard Report Builder

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@
 if ENV['SENTRY_API_KEY']
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_API_KEY']
-    config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+    config.environment = ENV.fetch('DEPLOYMENT_ENVIRONMENT') { Rails.env }
     config.enabled_environments = %w[production]
     config.release = Version::VERSION
     config.breadcrumbs_logger = %i[active_support_logger http_logger]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,8 @@ Rails.application.routes.draw do
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
   get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
-  get 'doc/ppd', to: redirect('/app/doc/ppd', status: 301)
-  get 'app/root/doc/ppd', to: redirect('app/doc/ppd', status: 301)
+  get 'doc/ppd', to: redirect('/app/doc/ppd', status: 302)
+  get 'app/root/doc/ppd', to: redirect('app/doc/ppd', status: 302)
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get 'landing/hpi', to: 'landing#hpi'
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
-  get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
+  get 'doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   get 'landing/hpi', to: 'landing#hpi'
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
-  get 'doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
+  get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
+  get 'doc/ppd', to: redirect('/app/doc/ppd', status: 301)
+  get 'app/root/doc/ppd', to: redirect('app/doc/ppd', status: 301)
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,6 @@ Rails.application.routes.draw do
   get 'doc/hpi', to: 'doc#hpi', as: 'hpi_doc'
   get 'doc/ukhpi', to: redirect('/app/ukhpi/doc', status: 302)
   get 'app/doc/ppd', to: 'doc#ppd', as: 'ppd_doc'
-  get 'doc/ppd', to: redirect('/app/doc/ppd', status: 302)
-  get 'app/root/doc/ppd', to: redirect('app/doc/ppd', status: 302)
   get 'doc/ukhpi-dsd', to: redirect('/app/ukhpi/doc/ukhpi-dsd', status: 302)
   get 'doc/ukhpi-user-guide', to: redirect('/app/ukhpi/doc/ukhpi-user-guide', status: 302)
   get 'doc/accessibility', to: 'doc#accessibility'

--- a/test/integration/documentation_test.rb
+++ b/test/integration/documentation_test.rb
@@ -14,16 +14,6 @@ class DocumentationTest < ActionDispatch::IntegrationTest
     assert_equal(302, response.status)
   end
 
-  test 'older PPD doc link redirects with permanent 302 status' do
-    get '/doc/ppd'
-    assert_equal(302, response.status)
-  end
-
-  test 'old PPD doc link redirects with permanent 302 status' do
-    get '/app/root/doc/ppd'
-    assert_equal(302, response.status)
-  end
-
   test 'ppd_doc_path variable links correctly' do
     get ppd_doc_path
     assert_response :success

--- a/test/integration/documentation_test.rb
+++ b/test/integration/documentation_test.rb
@@ -14,8 +14,24 @@ class DocumentationTest < ActionDispatch::IntegrationTest
     assert_equal(302, response.status)
   end
 
-  test 'PPD docs page' do
+  test 'older PPD doc link redirects with permanent 301 status' do
     get '/doc/ppd'
+    assert_equal(301, response.status)
+  end
+
+  test 'old PPD doc link redirects with permanent 301 status' do
+    get '/app/root/doc/ppd'
+    assert_equal(301, response.status)
+  end
+
+  test 'ppd_doc_path variable links correctly' do
+    get ppd_doc_path
+    assert_response :success
+  end
+
+  test 'ppd doc loads correctly' do
+    get ppd_doc_path
     assert_select 'h1', 'Price Paid Linked Data'
+    assert_select 'h2', 'What does the Price Paid Dataset consist of?'
   end
 end

--- a/test/integration/documentation_test.rb
+++ b/test/integration/documentation_test.rb
@@ -14,14 +14,14 @@ class DocumentationTest < ActionDispatch::IntegrationTest
     assert_equal(302, response.status)
   end
 
-  test 'older PPD doc link redirects with permanent 301 status' do
+  test 'older PPD doc link redirects with permanent 302 status' do
     get '/doc/ppd'
-    assert_equal(301, response.status)
+    assert_equal(302, response.status)
   end
 
-  test 'old PPD doc link redirects with permanent 301 status' do
+  test 'old PPD doc link redirects with permanent 302 status' do
     get '/app/root/doc/ppd'
-    assert_equal(301, response.status)
+    assert_equal(302, response.status)
   end
 
   test 'ppd_doc_path variable links correctly' do


### PR DESCRIPTION
Reconfigured the `detailed documentation` links, both english and welsh, to point to the `app/doc/ppd` path; alongside adding tests querying the new route to ensure the route is valid and contains the expected content. 

All redirections for any old routes will now handled by the proxy server.