### PR TITLE
Landing - Ensure links are distinguished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+## 1.7.7 - 2024-08
+
+- (Dan) Adds underlines to links in body text to meet WCAG 2.2 accessibiliy requirments[GH-126](https://github.com/epimorphics/lr-landing/issues/126)
+
 ## 1.7.6 - 2024-03-12
 
 - (Jon) Reconfigured the `detailed documentation` links, both english and welsh,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ cd lr-landing &&
 bundle install
 ```
 
+#### Trouble shooting bundle install
+
+If bundle install does not work add a .bundle directory and create a config
+file. So you now have .bundle/config.
+Add the following line to the config file.
+BUNDLE_RUBYGEMS__PKG__GITHUB__COM: "your-username:your-personal-access-token"
+Then run bundle install again and eveything should work.
+
 Start the app locally for development:
 
 ```sh

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,12 @@
   "bootstrap",
   "qonsole_rails/application",
   "lr_common_styles/lr-common";
+
+.row {
+  li,p,dl>dt, dl>dd {
+    a {
+      text-decoration: underline;
+    }
+  }
+}
+  

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@
   "lr_common_styles/lr-common";
 
 .row {
-  li,p,dl>dt, dl>dd {
+  li,p,dl>dt,dl>dd {
     a {
       text-decoration: underline;
     }

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  REVISION = 6
+  REVISION = 7
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This accessibility requirement mentions contrast as an issue. We only need to achieve a 3:1 contrast difference with the body text if there is no obvious visual indicator such as an underline. 

I have added an underline to the link text so this accessibility requirement is now met.

Please see this paragraph on [webAim](https://webaim.org/resources/linkcontrastchecker/#:~:text=Otherwise%2C%20link%20text%20must%20have,meet%20WCAG%202%20Level%20AA.) 

I haven't added underlines to the `English | Cymraeg` language selection because they are not surrounded by body text. 

![Screenshot from 2024-08-06 09-45-16](https://github.com/user-attachments/assets/6082b587-60fd-46cb-af2a-7f0fdc7490a4)

@tomguilbert do you agree that the language selection doesn't require an underline?


