### PR TITLE
Primarily Prometheus Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,26 +4,51 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-!/log/.keep
-.byebug_history
-.github-token
-.npmrc
-.tags
+# Ignore vscode config
 .vscode
-.yarn-integrity
+
+## Ignore bundler configuration:
 /.bundle
+/vendor/bundle
+/lib/bundler/man/
+
+# Ignore all logfiles and tempfiles.
 /log/*
-/node_modules
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
 /public/packs
 /public/packs-test
-/tmp
-coverage
-fc_simple.json
+/public/assets
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+/public/uploads
+
+### Rails specific ###
+.byebug_history
+/public/system
+/coverage/
+tmp
+
+# Ignore files specific to the development environment
 fc.json
+fc_simple.json
 index-names.txt
 index.json
-node_modules/
-public/assets
 tags
-yarn-debug.log*
-yarn-error.log
+
+# Ignore dot files used by environment or IDE tools
+.tags
+.tool-versions
+.github-token
+.npmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,26 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+## 1.8.0 - 2024-08
+
+- (Jon) Implemented improved boilerplate metrics integration to offer analysis of
+  current application usage stats
+- (Jon) Implemented the dynamic page title approach used in the other suite apps
+  to the accessibility and privacy translation templates
+- (Jon) Converted the privacy templates to match the same haml formatting
+  language used in the app
+- (Jon) Tweaked the application controller to improve selected language option
+  to be applied for the pages
+- (Jon) Reorganised makefile targets alphabetically as well as mirrored other
+  improvements from the other applications in the suite
+- (Jon) Updated .gitignore file to mirror the current approach in the other HMLR
+  apps
+
 ## 1.7.7 - 2024-08
 
 - (Dan) Updates gemfile to use v1.9.5 lr_common_styles
-- (Dan) Adds underlines to links in body text to meet WCAG 2.2 accessibiliy requirments[GH-126](https://github.com/epimorphics/lr-landing/issues/126)
+- (Dan) Adds underlines to links in body text to meet WCAG 2.2 accessibiliy
+  requirments[GH-126](https://github.com/epimorphics/lr-landing/issues/126)
 
 ## 1.7.6 - 2024-03-12
 
@@ -29,7 +45,8 @@ including the SPARQL Qonsole
 
 - (Jon) Updated the `app/controllers/application_controller.rb` to include the
   `before_action` for the `change_default_caching_policy` method to ensure the
-  default `Cache-Control` header for all requests is set to 5 minutes (300 seconds).
+  default `Cache-Control` header for all requests is set to 5 minutes (300
+  seconds).
 
 ## 1.7.3 - 2023-06-07
 
@@ -58,8 +75,8 @@ including the SPARQL Qonsole
 - (Jon) Updated and improved the build files for the new infrastructure use.
 - (Jon) Minor text changes to the `Gemfile` to include instructions for running
   Epimorphics specific gems locally during the development of those gems.
-- (Jon) Updated the production `json_rails_logger` gem version to be at least the
-  current version `~>0.3.5` (this is to cover out of sync release versions)
+- (Jon) Updated the production `json_rails_logger` gem version to be at least
+  the current version `~>0.3.5` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 # ! These "local" paths do not work with a docker image - use the repo instead
 # gem 'qonsole-rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
 # gem 'json_rails_logger', '~> 1.0.0', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', '~> 1.9.3', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
+# gem 'lr_common_styles', '~> 1.9', '>= 1.9.6', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
 # rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics github repo
@@ -46,5 +46,5 @@ gem 'qonsole-rails', git: 'https://github.com/epimorphics/qonsole-rails'
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger', '~> 1.0.0'
-  gem 'lr_common_styles', '~> 1.9', '>= 1.9.5'
+  gem 'lr_common_styles', '~> 1.9', '>= 1.9.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.16.0)
+    autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     bindex (0.8.1)
     bootstrap-sass (3.4.1)
@@ -155,7 +155,7 @@ GEM
     parser (3.1.1.0)
       ast (~> 2.4.1)
     prometheus-client (4.0.0)
-    puma (5.6.7)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.8)
@@ -263,7 +263,7 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.3)
+    lr_common_styles (1.9.6)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -290,7 +290,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   json_rails_logger (~> 1.0.0)!
-  lr_common_styles (~> 1.9.3)!
+  lr_common_styles (~> 1.9, >= 1.9.6)!
   prometheus-client (~> 4.0)
   puma
   qonsole-rails!

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ${GITHUB_TOKEN}:
 
 all: image
 
-assets:
+assets: auth
 	@./bin/bundle config set --local without 'development test'
 	@./bin/bundle install
 	@./bin/rails assets:clean assets:precompile

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets clean image lint publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint local publish realclean run tag test vars
 
 ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.13
@@ -27,23 +27,27 @@ REPO?=${ECR}/${IMAGE}
 GITHUB_TOKEN=.github-token
 BUNDLE_CFG=.bundle/config
 
-all: image
-
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
 	@./bin/bundle config set --local rubygems.pkg.github.com ${GPR_OWNER}:`cat ${GITHUB_TOKEN}`
 
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
 
+all: image
+
 assets:
-	@./bin/bundle config set --local without 'development'
+	@./bin/bundle config set --local without 'development test'
 	@./bin/bundle install
 	@./bin/rails assets:clean assets:precompile
 
 auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
+check: lint test
+	@echo "All checks passed."
+
 clean:
 	@[ -d public/assets ] && ./bin/rails assets:clobber || :
+	@@ rm -rf bundle coverage log node_modules
 
 image: auth
 	@echo Building ${REPO}:${TAG} ...
@@ -63,6 +67,12 @@ image: auth
 lint: assets
 	@./bin/bundle exec rubocop
 
+local:
+	@echo "Installing all packages ..."
+	@./bin/bundle install
+	@echo "Starting local server ..."
+	@./bin/rails server -p ${PORT}
+
 publish: image
 	@echo Publishing image: ${REPO}:${TAG} ...
 	@docker push ${REPO}:${TAG} 2>&1
@@ -71,16 +81,23 @@ publish: image
 realclean: clean
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
-run:
+run: start
 	@if docker network inspect dnet > /dev/null 2>&1; then echo "Using docker network dnet"; else echo "Create docker network dnet"; docker network create dnet; sleep 2; fi
+	@docker run -p ${PORT}:3000 -e API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
+
+server: assets start
+	@export SECRET_KEY_BASE=$(./bin/rails secret)
+	@API_SERVICE_URL=${API_SERVICE_URL} ./bin/rails server -p ${PORT}
+
+start:
 	@docker stop ${SHORTNAME} > /dev/null 2>&1 || :
 	@echo "Starting ${SHORTNAME} ..."
-	@docker run -p ${PORT}:3000 --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
 tag:
 	@echo ${TAG}
 
 test: assets
+	@echo "Running unit tests ..."
 	@./bin/rails test
 
 vars:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   # @param [Exception] exp the exception that caused the error
   # @return [ActiveSupport::Notifications::Event] provides an object-oriented
   # interface to the event
-  def instrument_internal_error(exp)
-    ActiveSupport::Notifications.instrument('internal_error.application', exception: exp)
+  def instrument_internal_error(exception)
+    ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,30 +2,37 @@
 
 # :nodoc:
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
+  # Prevent CSRF attacks by raising an exception. For APIs, you may want to use
+  # :null_session instead.
   protect_from_forgery with: :exception
-
-  before_action :set_locale, :change_default_caching_policy
+  before_action :change_default_caching_policy
+  before_action :set_locale
 
   private
 
-  # Set the user's preferred locale. An explicit locale set via
-  # the URL param `lang` is preeminent, otherwise we look to the
-  # user's preferred language specified via browser headers
+  # Set the user's preferred locale. An explicit locale set via the URL param
+  # `lang` is preeminent, otherwise we look to the user's preferred language
+  # specified via browser headers
   def set_locale
-    user_locale =
-      params['lang'] ||
-      http_accept_language.compatible_language_from(I18n.available_locales)
+    user_locale = params['lang']
+    user_locale ||= http_accept_language.compatible_language_from(I18n.available_locales)
 
     I18n.locale = user_locale if Rails.application.config.welsh_language_enabled
   end
 
   # * Set cache control headers for HMLR apps to be public and cacheable
-  # * Landing Page uses a time limit of 5 minutes (300 seconds)
-  # Sets the default `Cache-Control` header for all requests,
-  # unless overridden in the action
+  # * Landing Page uses a time limit of 5 minutes (300 seconds) Sets the default
+  # `Cache-Control` header for all requests, unless overridden in the action
   def change_default_caching_policy
     expires_in 5.minutes, public: true, must_revalidate: true if Rails.env.production?
+  end
+
+  # Notify subscriber(s) of an internal error event with the payload of the
+  # exception once done
+  # @param [Exception] exp the exception that caused the error
+  # @return [ActiveSupport::Notifications::Event] provides an object-oriented
+  # interface to the event
+  def instrument_internal_error(exp)
+    ActiveSupport::Notifications.instrument('internal_error.application', exception: exp)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,12 @@
 
 # :nodoc:
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception. For APIs, you may want to use
-  # :null_session instead.
-  protect_from_forgery with: :exception
-  before_action :change_default_caching_policy
-  before_action :set_locale
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
 
-  private
+  protect_from_forgery with: :exception
+  before_action :set_locale
+  before_action :change_default_caching_policy
 
   # Set the user's preferred locale. An explicit locale set via the URL param
   # `lang` is preeminent, otherwise we look to the user's preferred language
@@ -21,8 +20,9 @@ class ApplicationController < ActionController::Base
   end
 
   # * Set cache control headers for HMLR apps to be public and cacheable
-  # * Landing Page uses a time limit of 5 minutes (300 seconds) Sets the default
-  # `Cache-Control` header for all requests, unless overridden in the action
+  # * Landing Page uses a time limit of 5 minutes (300 seconds)
+  # Sets the default `Cache-Control` header for all requests,
+  # unless overridden in the action
   def change_default_caching_policy
     expires_in 5.minutes, public: true, must_revalidate: true if Rails.env.production?
   end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 1
-  MINOR = 7
-  REVISION = 7
+  MINOR = 8
+  REVISION = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/subscribers/action_dispatch_prometheus_subscriber.rb
+++ b/app/subscribers/action_dispatch_prometheus_subscriber.rb
@@ -7,22 +7,57 @@
 class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :action_controller
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def process_action(_event)
     mem = GetProcessMem.new
     Prometheus::Client.registry
                       .get(:memory_used_mb)
                       .set(mem.mb)
-
-    Prometheus::Client.registry
-                      .get(:thread_count)
-                      .set(Thread.list.select do |thread|
-                             %w[run sleep].include?(thread.status)
-                           end.count)
-
+    # description: 'Thread is aborting'
     Prometheus::Client.registry
                       .get(:process_threads)
-                      .set(Thread.list.select { |thread| thread.status == 'run' }.count)
+                      .set(
+                        Thread.list.select { |thread| thread.status == 'aborting' }.count,
+                        labels: {
+                          status: 'aborting'
+                        }
+                      )
+    # description: 'Thread is sleeping or waiting on I/O'
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(
+                        Thread.list.select { |thread| thread.status == 'sleep' }.count,
+                        labels: {
+                          status: 'sleep'
+                        }
+                      )
+    # description: 'Thread is executing'
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(
+                        Thread.list.select { |thread| thread.status == 'run' }.count,
+                        labels: {
+                          status: 'run'
+                        }
+                      )
+    # description: 'Thread is terminated normally'
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(
+                        Thread.list.select { |thread| thread.status == false }.count,
+                        labels: {
+                          status: 'false'
+                        }
+                      )
+    # description: 'Thread is terminated with an exception'
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(
+                        Thread.list.select { |thread| thread.status.nil? }.count,
+                        labels: {
+                          status: 'nil'
+                        }
+                      )
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/subscribers/action_dispatch_prometheus_subscriber.rb
+++ b/app/subscribers/action_dispatch_prometheus_subscriber.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Subscribe to `*.action_controller`` events
+#
+# Note: This is Rails 5 specific. In Rails 6, we'd subscribe to
+# `request.action_dispatch`
+class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :action_controller
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def process_action(_event)
+    mem = GetProcessMem.new
+    Prometheus::Client.registry
+                      .get(:memory_used_mb)
+                      .set(mem.mb)
+
+    Prometheus::Client.registry
+                      .get(:thread_count)
+                      .set(Thread.list.select do |thread|
+                             %w[run sleep].include?(thread.status)
+                           end.count)
+
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(Thread.list.select { |thread| thread.status == 'run' }.count)
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Subscribe to :data_api events
+class ApiPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :api
+
+  def response(event)
+    response = event.payload[:response]
+    duration = event.payload[:duration]
+
+    Prometheus::Client.registry
+                      .get(:api_status)
+                      .increment(labels: { status: response.status.to_s })
+
+    Prometheus::Client.registry
+                      .get(:api_requests)
+                      .increment(labels: { result: 'success' })
+
+    Prometheus::Client.registry
+                      .get(:api_response_times)
+                      .observe(duration)
+  end
+
+  def connection_failure(event)
+    exception = event.payload[:exception]
+    message = exception.message || exception.to_s
+
+    Prometheus::Client.registry
+                      .get(:api_requests)
+                      .increment(labels: { result: 'failure' })
+
+    Prometheus::Client.registry
+                      .get(:api_connection_failure)
+                      .increment(labels: { message: })
+  end
+
+  def service_exception(event)
+    exception = event.payload[:exception]
+    status = exception_status(exception)
+
+    return if status == 404
+
+    Prometheus::Client.registry
+                      .get(:api_service_exception)
+                      .increment(labels: { status: })
+  end
+
+  private
+
+  def exception_status(exception)
+    status = 500
+
+    begin
+      json = JSON.parse(exception.message)
+      status = json['status'] if json&.key?('status')
+    rescue JSON::ParserError
+      # was not JSON after all
+    end
+
+    status = exception.status if exception.respond_to?(:status)
+
+    status
+  end
+end

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -4,13 +4,15 @@
 class ApiPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :api
 
+  # rubocop:disable Metrics/MethodLength
   def response(event)
     response = event.payload[:response]
     duration = event.payload[:duration]
+    status = response.status.to_s
 
     Prometheus::Client.registry
                       .get(:api_status)
-                      .increment(labels: { status: response.status.to_s })
+                      .increment(labels: { status: status })
 
     Prometheus::Client.registry
                       .get(:api_requests)
@@ -20,6 +22,7 @@ class ApiPrometheusSubscriber < ActiveSupport::Subscriber
                       .get(:api_response_times)
                       .observe(duration)
   end
+  # rubocop:enable Metrics/MethodLength
 
   def connection_failure(event)
     exception = event.payload[:exception]
@@ -31,7 +34,7 @@ class ApiPrometheusSubscriber < ActiveSupport::Subscriber
 
     Prometheus::Client.registry
                       .get(:api_connection_failure)
-                      .increment(labels: { message: })
+                      .increment(labels: { message: message })
   end
 
   def service_exception(event)
@@ -42,7 +45,7 @@ class ApiPrometheusSubscriber < ActiveSupport::Subscriber
 
     Prometheus::Client.registry
                       .get(:api_service_exception)
-                      .increment(labels: { status: })
+                      .increment(labels: { status: status })
   end
 
   private

--- a/app/subscribers/application_prometheus_subscriber.rb
+++ b/app/subscribers/application_prometheus_subscriber.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Subscribe to :application events
+class ApplicationPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :application
+
+  def internal_error(event)
+    message = event.payload[:exception]
+    Prometheus::Client.registry
+                      .get(:internal_application_error)
+                      .increment(labels: { message: message.to_s })
+  end
+end

--- a/app/views/doc/_accessibility_cy.html.haml
+++ b/app/views/doc/_accessibility_cy.html.haml
@@ -1,7 +1,8 @@
+- content_for(:title, 'Datganiad hygyrchedd')
+- content_for(:description, 'Datganiad hygyrchedd ar gyfer cymwysiadau data agored: archwiliwr Data Pris a Dalwyd, adeiladwr adroddiadau safonol a Mynegai Prisiau Tai y DU')
 %article
   %h1.heading-large
-    Datganiad hygyrchedd ar gyfer cymwysiadau data agored: archwiliwr Data Pris a
-    Dalwyd, adeiladwr adroddiadau safonol a Mynegai Prisiau Tai y DU
+    = yield(:description)
 
   %p
     Cofrestrfa Tir EM sy&#8217;n rhedeg y wefan hon. Rydym am i gynifer o bobl â

--- a/app/views/doc/_accessibility_en.html.haml
+++ b/app/views/doc/_accessibility_en.html.haml
@@ -1,8 +1,8 @@
+- content_for(:title, 'Accessibility statement')
+- content_for(:description, 'Accessibility statement for open data applications: Price Paid Data (PPD) explorer, standard reports builder and UK House Price Index (UKHPI)')
 %article
   %h1.heading-large
-    Accessibility statement for open data applications: Price Paid
-    Data (PPD) explorer, standard reports builder and UK House
-    Price Index (UKHPI)
+    = yield(:description)
 
   %p
     This website is run by HM Land Registry.  We want as many people as

--- a/app/views/doc/_privacy_cy.html.haml
+++ b/app/views/doc/_privacy_cy.html.haml
@@ -1,37 +1,53 @@
-<article>
-  <h1>Hysbysiad preifatrwydd</h1>
-  <p>
+- content_for(:title, 'Hysbysiad preifatrwydd')
+
+%article
+  %h1
+    = yield(:title)
+
+  %p
     Mae’r hysbysiad preifatrwydd hwn yn egluro beth rydym yn ei wneud gyda’r wybodaeth a gawn oddi wrthych pan fyddwch yn defnyddio’n gwasanaeth.
-  </p>
-  <h2>Cwcis</h2>
-  <p>
+
+  %h2
+    Cwcis
+  %p
     Ffeiliau bach sy’n cael eu harbed ar eich ffôn, llechen neu gyfrifiadur pan fyddwch yn ymweld â gwefan yw cwcis. Rydym yn defnyddio cwcis i wneud i’r wefan weithio ac i ddeall sut rydych yn defnyddio’n gwasanaeth, er enghraifft y tudalennau rydych yn ymweld â nhw.
-  </p>
-  <h3>Cwcis hanfodol</h3>
-  <p>
+
+  %h3
+    Cwcis hanfodol
+  %p
     Mae cwcis hanfodol yn cadw’ch gwybodaeth yn ddiogel wrth ichi ddefnyddio’r gwasanaeth hwn. Nid oes angen eich caniatâd arnom i’w defnyddio.
-  </p>
-  <ul class="list list-bullet">
-    <li>Dynodydd sesiwn unigryw</li>
-  </ul>
-  <h3>Cwcis dadansoddol (dewisol)</h3>
-  <p>
+
+  %ul.list.list-bullet
+    %li
+      Dynodydd sesiwn unigryw
+
+
+  %h3
+    Cwcis dadansoddol (dewisol)
+  %p
     Gyda’ch caniatâd, rydym yn defnyddio Google Analytics i gasglu data am sut rydych yn defnyddio’r gwasanaeth. Rydym yn defnyddio’r wybodaeth hon i’n helpu i wella’r gwasanaeth ar sail anghenion defnyddwyr.
-  </p>
-  <p>
+
+  %p
     Ni chaniateir i Google ddefnyddio neu rannu ein data dadansoddol gydag unrhyw un.
-  </p>
-  <p>
+
+  %p
     Mae Google Analytics yn gosod cwcis sy’n storio gwybodaeth ddienw am y canlynol:
-  </p>
-  <ul class="list list-bullet">
-    <li>y tudalennau rydych yn ymweld â nhw</li>
-    <li>pa mor hir rydych yn ei dreulio ar bob tudalen</li>
-    <li>sut y cyrhaeddwyd y gwasanaeth</li>
-    <li>ar beth rydych yn clicio wrth ymweld â’r gwasanaeth</li>
-  </ul>
-  <h3>Cwcis sy’n cofio’ch gosodiadau</h3>
-  <p>
+
+  %ul.list.list-bullet
+    %li
+      y tudalennau rydych yn ymweld â nhw
+
+    %li
+      pa mor hir rydych yn ei dreulio ar bob tudalen
+
+    %li
+      sut y cyrhaeddwyd y gwasanaeth
+
+    %li
+      ar beth rydych yn clicio wrth ymweld â’r gwasanaeth
+
+
+  %h3
+    Cwcis sy’n cofio’ch gosodiadau
+  %p
     Mae’r cwcis hyn yn gwneud pethau fel cofio eich ffafriaeth a’r dewisiadau a wnewch i bersonoli’ch profiad o ddefnyddio’r wefan.
-  </p>
-</article>

--- a/app/views/doc/_privacy_en.html.haml
+++ b/app/views/doc/_privacy_en.html.haml
@@ -1,40 +1,50 @@
-<article>
-  <h1>Privacy notice</h1>
-  <p>
+- content_for(:title, 'Privacy notice')
+
+%article
+  %h1
+    = yield(:title)
+  %p
     This privacy notice tells you what we do with the information we collect
     from you when you use our service.
-  </p>
-  <h2>Cookies</h2>
-  <p>
+  %h2
+    Cookies
+  %p
     Cookies are small files saved on your phone, tablet or computer when you
     visit a website. We use cookies to make the site work and understand how you
     use our service, such as the pages you visit.
-  </p>
-  <h3>Essential cookies</h3>
-  <p>
+  %h3
+    Essential cookies
+  %p
     Essential cookies keep your information secure while you use this service.
     We do not need your permission to use them.
-  </p>
-  <ul class="list list-bullet">
-    <li>Unique session ID</li>
-  </ul>
-  <h3>Analytics cookies (optional)</h3>
-  <p>
+  %ul.list.list-bullet
+    %li
+      Unique session ID
+
+  %h3
+    Analytics cookies (optional)
+  %p
     With your permission, we use Google Analytics to collect data about how you
     use the service. We use this information to help us improve the service
     based on user needs.
-  </p>
-  <p>Google is not allowed to use or share our analytics data with anyone.</p>
-  <p>Google analytics sets cookies that store anonymised information about:</p>
-  <ul class="list list-bullet">
-    <li>the pages you visit</li>
-    <li>how long you spend on each page</li>
-    <li>how you got to the service</li>
-    <li>what you click on while you're visiting the service</li>
-  </ul>
-  <h3>Cookies that remember your settings</h3>
-  <p>
+
+  %p
+    Google is not allowed to use or share our analytics data with anyone.
+  %p
+    Google analytics sets cookies that store anonymised information about:
+  %ul.list.list-bullet
+    %li
+      the pages you visit
+    %li
+      how long you spend on each page
+    %li
+      how you got to the service
+    %li
+      what you click on while you're visiting the service
+
+  %h3
+    Cookies that remember your settings
+  %p
     These cookies do things like remember your preferences and the choices you
     make to personalise your experience of using the site.
-  </p>
-</article>
+

--- a/app/views/doc/hpi.html.haml
+++ b/app/views/doc/hpi.html.haml
@@ -1,4 +1,7 @@
-%h2 House Price Index Linked Data
+- content_for(:title, 'House Price Index Linked Data')
+
+%h2
+  = yield(:title)
 %h3
   What does the House Price Index Dataset consist of?
 %p

--- a/app/views/doc/ppd.html.haml
+++ b/app/views/doc/ppd.html.haml
@@ -1,4 +1,6 @@
-%h1 Price Paid Linked Data
+- content_for(:title, 'Price Paid Linked Data')
+%h1
+  = yield(:title)
 %h2 What does the Price Paid Dataset consist of?
 %p
   HM Land Registry publish Price Paid Data for England and Wales on a monthly basis. New transactions are added

--- a/app/views/doc/privacy.html.erb
+++ b/app/views/doc/privacy.html.erb
@@ -1,2 +1,0 @@
-<%= render partial: 'shared/lang_switch' %>
-<%= render partial: "privacy_#{I18n.locale}"%>

--- a/app/views/doc/privacy.html.haml
+++ b/app/views/doc/privacy.html.haml
@@ -1,0 +1,2 @@
+= render partial: 'shared/lang_switch'
+= render partial: "privacy_#{I18n.locale}"

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -1,7 +1,9 @@
+- content_for(:title, 'Data Agored')
 .row
   .col-md-12
     %h1.heading-large
-      Data Agored
+      = yield(:title)
+
     %p
       Mae Cofrestrfa Tir EM yn cyhoeddi’r setiau data cyhoeddus canlynol fel
       rhan o’n hymrwymiad i flaenoriaethau’r Llywodraeth i dwf economaidd

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -1,7 +1,8 @@
+- content_for(:title, 'Open Data')
 .row
   .col-md-12
     %h1.heading-large
-      Open Data
+      = yield(:title)
     %p
       HM Land Registry publishes the following public datasets on GOV.UK
       as part of our commitment to the Government’s priorities

--- a/app/views/landing/hpi.html.haml
+++ b/app/views/landing/hpi.html.haml
@@ -1,4 +1,6 @@
-%h1 Change to House Price Index data
+- content_for(:title, "Change to House Price Index data" )
+%h1
+  = yield(:title)
 %p
   From 14 June 2016 the HM Land Registry House Price Index was replaced by the
   %strong UK House Price Index,

--- a/config.ru
+++ b/config.ru
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 # This file is used by Rack-based servers to start the application.
-
 require_relative 'config/environment'
 
-require 'prometheus/middleware/collector'
-require 'prometheus/middleware/exporter'
+unless Rails.env.test?
+  require 'prometheus/middleware/collector'
+  require 'prometheus/middleware/exporter'
 
-use Prometheus::Middleware::Collector
-use Prometheus::Middleware::Exporter
+  use Prometheus::Middleware::Collector
+  use Prometheus::Middleware::Exporter
+end
 
 require ::File.expand_path('config/environment', __dir__)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,8 +34,9 @@ module Rails
         level: 'INFO',
         message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{origin}"
       }
-
+      # rubocop:disable Rails/Output
       puts(msg.to_json)
+      # rubocop:enable Rails/Output
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Rails
         message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{origin}"
       }
 
-      puts(msg.to_json) # rubocop:disable Rails/Output
+      puts(msg.to_json)
     end
   end
 end
@@ -53,6 +53,8 @@ module LrLanding
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = true
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = %i[en cy]
   end
 end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -40,13 +40,10 @@ prometheus.gauge(
 )
 
 prometheus.gauge(
-  :thread_count,
-  docstring: 'The number of threads currently alive'
-)
-
-prometheus.gauge(
   :process_threads,
-  docstring: 'The number of currently running threads'
+  docstring: 'The number of process threads, labelled by status',
+  labels: [:status],
+  preset_labels: { status: 'total' }
 )
 
 # Histograms

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+prometheus = Prometheus::Client.registry
+
+# Prometheus counters
+prometheus.counter(
+  :api_status,
+  docstring: 'Count of API responses, labelled by status',
+  labels: [:status]
+)
+
+prometheus.counter(
+  :api_requests,
+  docstring: 'Count of API responses, labelled by succeeded true/false',
+  labels: [:result]
+)
+
+prometheus.counter(
+  :api_connection_failure,
+  docstring: 'Total of failures to connect to API, labelled by reason',
+  labels: [:message]
+)
+
+prometheus.counter(
+  :api_service_exception,
+  docstring: 'Total of other errors when processing API responses',
+  labels: [:status]
+)
+
+prometheus.counter(
+  :internal_application_error,
+  docstring: 'Unexpected events and internal error count',
+  labels: [:message]
+)
+
+# Prometheus gauges
+prometheus.gauge(
+  :memory_used_mb,
+  docstring: 'Process memory usage in mb'
+)
+
+prometheus.gauge(
+  :thread_count,
+  docstring: 'The number of threads currently alive'
+)
+
+prometheus.gauge(
+  :process_threads,
+  docstring: 'The number of currently running threads'
+)
+
+# Histograms
+
+prometheus.histogram(
+  :api_response_times,
+  docstring: 'Histogram of back-end API response times',
+  buckets: Prometheus::Client::Histogram.exponential_buckets(start: 0.0005, count: 16)
+)


### PR DESCRIPTION
Focussing primarily on ticket [#148](https://github.com/epimorphics/hmlr-linked-data/issues/148) for the addition of Prometheus metrics endpoint to the landing page, additional changes for accessibility, useability, and functionality have been interspersed.

- Implemented improved boilerplate metrics integration to offer analysis of   current application usage stats
- Implemented the dynamic page title approach used in the other suite apps to the accessibility and privacy translation templates
- Converted the privacy templates to match the same haml formatting language used in the app
- Tweaked the application controller to improve selected language option to be applied for the pages
- Reorganised makefile targets alphabetically as well as mirrored other improvements from the other applications in the suite
- Updated .gitignore file to mirror the current approach in the other HMLR apps

 