### PR TITLE
Application Configuration Unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
-## 1.8.0 - 2024-08
+## 1.8.0 - 2024-09
 
-- (Bogdan) Fixed a bug where the language selector was not working correctly when
-  the user was on the accessibility or privacy pages [GH-130](https://github.com/epimorphics/lr-landing/issues/130)
-- (Jon) Implemented improved boilerplate metrics integration to offer analysis of
-  current application usage stats
+- (Jon) Moved all mirrored configuration settings from individual environments
+  into the application configuration to reduce the need to manage multiple
+  sources of truth
+- (Bogdan) Fixed a bug where the language selector was not working correctly
+  when the user was on the accessibility or privacy pages
+  [GH-130](https://github.com/epimorphics/lr-landing/issues/130)
+- (Jon) Implemented improved boilerplate metrics integration to offer analysis
+  of current application usage stats
 - (Jon) Implemented the dynamic page title approach used in the other suite apps
   to the accessibility and privacy translation templates
 - (Jon) Converted the privacy templates to match the same haml formatting
@@ -23,8 +27,8 @@ including the SPARQL Qonsole
 ## 1.7.7 - 2024-08
 
 - (Dan) Updates gemfile to use v1.9.5 lr_common_styles
-- (Dan) Adds underlines to links in body text to meet WCAG 2.2 accessibility requirements
-  [GH-126](https://github.com/epimorphics/lr-landing/issues/126)
+- (Dan) Adds underlines to links in body text to meet WCAG 2.2 accessibility
+  requirements [GH-126](https://github.com/epimorphics/lr-landing/issues/126)
 
 ## 1.7.6 - 2024-03-12
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,14 +265,14 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.7)
+    lr_common_styles (1.9.8)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
       govuk_frontend_toolkit (~> 4.18.1)
       govuk_template (~> 0.18.1)
       haml-rails (~> 2.0.0)
-      jquery-rails (~> 4.3.5)
+      jquery-rails (>= 4.3.5, < 4.7.0)
       lodash-rails (~> 4.17.14)
       modernizr-rails (~> 2.7.1)
       modulejs-rails (~> 2.2.0.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,16 @@ module LrLanding
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Use default paths for documentation.
+    config.accessibility_document_path = '/accessibility'
+    config.privacy_document_path = '/privacy'
+
+    # feature flag for showing the Welsh language switch affordance
+    config.welsh_language_enabled = true
+
+    # Set the contact email address to Land Registry supplied address
+    config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,14 +55,4 @@ Rails.application.configure do
   # API location can be specified in the environment but defaults to the dev service
   # Here we are still providing the API_SERVICE_URL for qonsole
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/accessibility'
-  config.privacy_document_path = '/privacy'
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,14 +89,4 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   # API location is not used on the landing page, but is required by all other apps
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/accessibility'
-  config.privacy_document_path = '/privacy'
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,14 +43,4 @@ Rails.application.configure do
   $stdout.sync = true
   # Log the stdout output to the Epimorphics JSON logging gem
   config.logger = JsonRailsLogger::Logger.new($stdout)
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/accessibility'
-  config.privacy_document_path = '/privacy'
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end


### PR DESCRIPTION
Moved all mirrored configuration settings from individual environments into the application configuration to reduce the need to manage multiple sources