### PR TITLE
Task: Load Qonsole Rails as a gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This app presents the landing page experience for landregistry.data.gov.uk,
 including the SPARQL Qonsole
 
+# 2.0.4 - 2025-02
+
+- (Jon) Removed old git reference for the qonsole_rails gem.
+- (Jon) Added the qonsole_rails gem to the source block instead.
+- (Jon) Updated several gems to their latest versions.
+- (Jon) Cleaned up commented-out paths in the Gemfile.
+
 ## 2.0.3 - 2025-01
 
 - (Jon) Improves error metrics reporting to ensure that logging always happens

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,6 @@ gem 'prometheus-client'
 gem 'puma'
 gem 'sentry-rails'
 
-# TODO: Add this to the epimorphics package registry as a gem
-gem 'qonsole-rails', git: 'https://github.com/epimorphics/qonsole-rails'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
@@ -37,10 +34,11 @@ end
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
+  gem 'qonsole_rails'
 end
 
 # TODO: While running the rails app locally for testing you can set gems to your local path
 # ! These "local" paths do not work with a docker image - use the repo instead
-# gem 'qonsole-rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
+# gem 'qonsole_rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
 # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
 # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/epimorphics/qonsole-rails
-  revision: b9d03a5ee0204a90cdcb732aeb0b5b87a28a78d7
-  specs:
-    qonsole-rails (1.0.2)
-      faraday
-      faraday-encoding
-      faraday_middleware
-      font-awesome-rails
-      haml-rails
-      jquery-datatables-rails
-      jquery-rails
-      lodash-rails
-      modulejs-rails
-      rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -93,19 +77,19 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     benchmark (0.4.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     bindex (0.8.1)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.3.0)
     byebug (11.1.3)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
     drb (2.2.1)
-    erubi (1.13.0)
+    erubi (1.13.1)
     execjs (2.10.0)
     faraday (1.10.4)
       faraday-em_http (~> 1.0)
@@ -125,8 +109,8 @@ GEM
       faraday
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -134,16 +118,14 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm-linux-musl)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86-linux-musl)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
     get_process_mem (1.0.0)
@@ -169,10 +151,11 @@ GEM
       haml (>= 4.0.6)
       railties (>= 5.1)
     http_accept_language (2.1.1)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
-    irb (1.14.1)
+    irb (1.15.1)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.13.0)
@@ -187,17 +170,17 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.9.0)
-    language_server-protocol (3.17.0.3)
+    json (2.9.1)
+    language_server-protocol (3.17.0.4)
     lodash-rails (4.17.21)
       railties (>= 3.1)
-    logger (1.6.2)
+    logger (1.6.5)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.23.1)
+    loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -212,44 +195,52 @@ GEM
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
     multipart-post (2.4.1)
-    net-imap (0.5.1)
+    net-imap (0.5.5)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.17.1-aarch64-linux)
+    nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.17.1-arm-linux)
+    nokogiri (1.18.2-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.17.1-arm64-darwin)
+    nokogiri (1.18.2-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.17.1-x86-linux)
+    nokogiri (1.18.2-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.17.1-x86_64-darwin)
+    nokogiri (1.18.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.1-x86_64-linux)
+    nokogiri (1.18.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.2-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
-    prometheus-client (4.2.3)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    prometheus-client (4.2.4)
       base64
-    psych (5.2.1)
+    psych (5.2.3)
       date
       stringio
-    puma (6.5.0)
+    puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.8)
-    rack-session (2.0.0)
+    rack (3.1.9)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
@@ -271,7 +262,7 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.2.1)
@@ -287,26 +278,26 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.8.1)
+    rdoc (6.12.0)
       psych (>= 4.0.0)
-    regexp_parser (2.9.3)
-    reline (0.5.12)
+    regexp_parser (2.10.0)
+    reline (0.6.0)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
-    rubocop (1.69.1)
+    rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.36.2, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.36.2)
+    rubocop-ast (1.38.0)
       parser (>= 3.3.1.0)
-    rubocop-rails (2.27.0)
+    rubocop-rails (2.29.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
@@ -328,11 +319,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    securerandom (0.4.0)
-    sentry-rails (5.22.0)
+    securerandom (0.4.1)
+    sentry-rails (5.22.4)
       railties (>= 5.0)
-      sentry-ruby (~> 5.22.0)
-    sentry-ruby (5.22.0)
+      sentry-ruby (~> 5.22.4)
+    sentry-ruby (5.22.4)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sprockets (4.2.1)
@@ -345,13 +336,13 @@ GEM
     stringio (3.1.2)
     temple (0.10.3)
     thor (1.3.2)
-    tilt (2.4.0)
-    timeout (0.4.2)
+    tilt (2.6.0)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (3.1.2)
+    unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     useragent (0.16.11)
@@ -360,7 +351,8 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket-driver (0.7.6)
+    websocket-driver (0.7.7)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.7.1)
@@ -385,20 +377,27 @@ GEM
       modulejs-rails
       rails
       sass-rails
+    qonsole_rails (2.0.0)
+      faraday
+      faraday-encoding
+      faraday_middleware
+      font-awesome-rails
+      haml-rails
+      jquery-datatables-rails
+      jquery-rails
+      lodash-rails
+      modulejs-rails
+      rails
+      rubocop
+      rubocop-rails
 
 PLATFORMS
-  aarch64-linux
   aarch64-linux-gnu
   aarch64-linux-musl
-  arm-linux
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  x86-linux
-  x86-linux-gnu
-  x86-linux-musl
   x86_64-darwin
-  x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
 
@@ -413,7 +412,7 @@ DEPENDENCIES
   lr_common_styles!
   prometheus-client
   puma
-  qonsole-rails!
+  qonsole_rails!
   rails
   rubocop
   rubocop-rails
@@ -423,4 +422,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.5.20
+   2.5.23

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 0
-  REVISION = 3
+  REVISION = 4
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR updates the codebase to include the following changes:

- Removed old git reference for the qonsole_rails gem
- Added qonsole_rails gem to the source block
- Updated several gems to their latest versions
- Cleaned up commented-out paths in the Gemfile

## Attached tickets:

- https://github.com/epimorphics/hmlr-linked-data/issues/93