### PR TITLE
Task: Startup and shutdown logs now json 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ including the SPARQL Qonsole
 
 # 2.0.4 - 2025-02
 
+- (Jon) Changed the way boot information is printed.
+- (Jon) Switched to JSON format for better compatibility with logging services.
+- (Jon) Refactored method to improve clarity and structure.
+- (Jon) Made the version string immutable by freezing it
+- (Jon) Included `puma-metrics` gem for better monitoring as now using Rails 6 or greater
+- (Jon) Updated Gemfile and Gemfile.lock to reflect the addition
+- (Jon) Set up a configurable metrics port with a default value.
+- (Jon) Updated the binding URL for the metrics server in development.
 - (Jon) Removed old git reference for the qonsole_rails gem.
 - (Jon) Added the qonsole_rails gem to the source block instead.
 - (Jon) Updated several gems to their latest versions.

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'http_accept_language'
 gem 'jbuilder'
 gem 'prometheus-client'
 gem 'puma'
+gem 'puma-metrics'
 gem 'sentry-rails'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,9 @@ GEM
       stringio
     puma (6.6.0)
       nio4r (~> 2.0)
+    puma-metrics (1.4.0)
+      prometheus-client (>= 0.10)
+      puma (>= 6.0)
     racc (1.8.1)
     rack (3.1.9)
     rack-session (2.1.0)
@@ -412,6 +415,7 @@ DEPENDENCIES
   lr_common_styles!
   prometheus-client
   puma
+  puma-metrics
   qonsole_rails!
   rails
   rubocop

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -5,5 +5,5 @@ module Version
   MINOR = 0
   REVISION = 4
   SUFFIX = nil
-  VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}"
+  VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,21 +22,21 @@ require 'qonsole_rails'
 # is written out in JSON format that our combined logging service can handle
 # This version is Rails 5.x specific. A different pattern is needed for Rails 6
 # applications.
+# Monkey-patch the bit of Rails that emits the start-up log message, so that it
+# is written out in JSON format that our combined logging service can handle
 module Rails
   # :nodoc:
-  class Server
+  module Command
     # :nodoc:
-    def print_boot_information
-      origin = "on #{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
-
-      msg = {
-        ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
-        level: 'INFO',
-        message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{origin}"
-      }
-      # rubocop:disable Rails/Output
-      puts(msg.to_json)
-      # rubocop:enable Rails/Output
+    class ServerCommand
+      def print_boot_information(server, url)
+        msg = {
+          ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
+          level: 'INFO',
+          message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+        }
+        say msg.to_json
+      end
     end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -39,12 +39,14 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-# Uncomment the following line once ruby is updated to 2.7 or greater to allow
-# the use of the puma-metrics plugin as we're using puma 6.0.0 or greater
 # Additional metrics from the Puma server to be exposed in the /metrics endpoint
-# plugin :metrics
+plugin :metrics
+# Specifies the `metrics_port` that Puma will listen on to export metrics;
+# default is 9393.
+metrics_port = ENV.fetch('METRICS_PORT', 9393)
+
 # Bind the metric server to "url". "tcp://" is the only accepted protocol.
-# metrics_url 'tcp://0.0.0.0:9393'
+metrics_url "tcp://0.0.0.0:#{metrics_port}" if Rails.env.development?
 
 # Use a custom log formatter to emit Puma log messages in a JSON format
 log_formatter do |str|


### PR DESCRIPTION
This PR updates the startup and shutdown logs to conform to the expected JSON format as requested in [#67](https://github.com/epimorphics/lr-landing/issues/67):

```json
{"ts":"2025-02-19T12:53:06.874Z","level":"INFO","message":"Starting Rackup::Handler::Puma Rails 7.2.2.1 in development "}
{"ts":"2025-02-19T12:53:07.187Z","level":"INFO","message":"* Starting metrics server on tcp://0.0.0.0:9394"}
{"ts":"2025-02-19T12:53:07.195Z","level":"INFO","message":"Puma starting in single mode..."}
{"ts":"2025-02-19T12:53:07.195Z","level":"INFO","message":"* Puma version: 6.6.0 (\"Return to Forever\")"}
{"ts":"2025-02-19T12:53:07.195Z","level":"INFO","message":"* Ruby version: ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-darwin24]"}
{"ts":"2025-02-19T12:53:07.196Z","level":"INFO","message":"*  Min threads: 5"}
{"ts":"2025-02-19T12:53:07.196Z","level":"INFO","message":"*  Max threads: 5"}
{"ts":"2025-02-19T12:53:07.196Z","level":"INFO","message":"*  Environment: development"}
{"ts":"2025-02-19T12:53:07.196Z","level":"INFO","message":"*          PID: 38373"}
{"ts":"2025-02-19T12:53:07.197Z","level":"INFO","message":"* Listening on http://127.0.0.1:3000"}
{"ts":"2025-02-19T12:53:07.197Z","level":"INFO","message":"* Listening on http://[::1]:3000"}
{"ts":"2025-02-19T12:53:07.198Z","level":"INFO","message":"Use Ctrl-C to stop"}
^C
{"ts":"2025-02-19T12:59:56.854Z","level":"INFO","message":"- Gracefully stopping, waiting for requests to finish"}
{"ts":"2025-02-19T12:59:56.863Z","level":"INFO","message":"=== puma shutdown: 2025-02-19 12:59:56 +0000 ==="}
{"ts":"2025-02-19T12:59:56.863Z","level":"INFO","message":"- Goodbye!"}
```

### Additional changes:

- Made the version string immutable by freezing it
- Included `puma-metrics` gem for better monitoring as now using Rails 6 or greater
- Updated Gemfile and Gemfile.lock to reflect the addition
- Set up a configurable metrics port with a default value.
- Updated the binding URL for the metrics server in development.