### PR TITLE
Limit bot crawling of UKHPI

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,5 +9,6 @@ Disallow: /so
 Disallow: /anything
 Disallow: /thing
 Disallow: /app/ppd/search?
+Disallow: /app/ukhpi/browse?
 Allow: /
 


### PR DESCRIPTION
We want well behaved bots to index the root UKHPI app but there are just too many links off the browse and recently we've seen substantial traffic from Googlebot (which we would normally allow) crawling these at up to 10 requests a second.

This is not urgent, we've temporarily added Google bot to all the others it our growing block list.