### PR TITLE
Task: Prep for Release Candidate v2.2.1

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,6 +15,16 @@ if echo "$BRANCH_NAME" | grep -q '^(hotfix)|(rebase)|(production)*$'; then
  	printf '\n\033[0;32mNo checks necessary on "%s", skipping hooks... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
+
+# Skip hook if all staged files only markdown (.md) files
+files=$(git diff --cached --name-only)
+files_to_check=$(echo "$files" | grep '\.md$')
+
+if [ -n "$files_to_check" ] && [ -z "$(echo "$files" | grep -v '\.md$')" ]; then
+  printf '\n\033[0;32mOnly markdown files staged (%s), skipping hook.\033[0m\n' "$files_to_check"
+  exit 0
+fi
+
 # Check for existence of "new or modified" files
 if ! git update-index -q --ignore-submodules --refresh; then
 	printf '\n\033[0;31mUp-to-date check failed😖\033[0m\n'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ including the SPARQL Qonsole
 
 ## Unreleased
 
+## 2.2.1 - 2025-08
+
 - Updated LR Common Styles gem to continue to address security issues
+- Added logic to bypass pre-push checks when only markdown files are staged
 
 ## 2.2.0 - 2025-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ including the SPARQL Qonsole
 
 ## Unreleased
 
+- Updated LR Common Styles gem to continue to address security issues
+
+## 2.2.0 - 2025-08
+
 - Bumped rails and all related gems to version 8.0.2.1
 - Upgraded rubocop and rubocop-rails to latest 1.x and 2.x releases
 - Updated rack to 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ including the SPARQL Qonsole
   other gems for security and compatibility
 - Synchronised dependency constraints across related gems
 
-## 2.1.2 - 2025-07
+## 2.1.3 - 2025-07
 
 - Updated `qonsole_rails` version to include latest improvements
 - Upgrade dependency management to improve project stability
 - Enhance Docker handling in scripts with refined command order
 - Introduce documentation for git hooks to streamline onboarding
 - Optimise makefile by removing redundant elements
+
+## 2.1.2 - 2025-07
+
 - Updated various gems to new versions, including `qonsole_rails`,
   `lr_common_styles`, and `reline`.
 - Notable updates include major upgrades in `faraday`, `rubocop`, `nokogiri`,

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 2
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 2
-  MINOR = 1
-  PATCH = 3
+  MINOR = 2
+  PATCH = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This pull request introduces a new patch release (v2.2.1) with updates focused on improving developer workflow and addressing security concerns. The most notable change is the addition of logic to bypass pre-push git hooks when only markdown files are staged, streamlining documentation updates. The LR Common Styles gem has also been updated for ongoing security improvements.

Release and workflow improvements:

* Updated the version to `2.2.1` in `app/lib/version.rb` to reflect the new release.
* Added a changelog entry for v2.2.1 in `CHANGELOG.md`, documenting the LR Common Styles gem update and the markdown-only pre-push hook bypass.

Developer experience:

* Enhanced `.githooks/pre-push` to skip all checks if only markdown files are staged, reducing unnecessary friction for documentation changes.