### PR TITLE
fix: update documentation links to direct URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ including the SPARQL Qonsole
 
 ## 2.2.1 - 2025-08
 
+- Resolved incorrect link to PPD Detailed Documentation
 - Updated LR Common Styles gem to continue to address security issues
 - Added logic to bypass pre-push checks when only markdown files are staged
 

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -93,7 +93,7 @@
     %h3.heading-small Gwybodaeth bellach
     %ul.list.list-bullet
       %li
-        = link_to('dogfennaeth fanwl', ppd_doc_path, 'aria-label' => 'dogfennaeth fanwl ar gyfer Lluniwr Adroddiad Data Pris a Dalwyd')
+        = link_to('dogfennaeth fanwl', '/app/doc/ppd', 'aria-label' => 'dogfennaeth fanwl ar gyfer Lluniwr Adroddiad Data Pris a Dalwyd')
         am y Data Pris a Dalwyd, y model data, a defnyddio’r data.
 
     %h2#standard-reports.heading-medium Lluniwr Adroddiad Safonol

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -92,7 +92,7 @@
     %h3.heading-small Further information
     %ul.list.list-bullet
       %li
-        = link_to('detailed documentation', ppd_doc_path, 'aria-label' => 'detailed documentation for the Price Paid Data Report Builder')
+        = link_to('detailed documentation', '/app/doc/ppd', 'aria-label' => 'detailed documentation for the Price Paid Data Report Builder')
         about the Price Paid Data, the data model, and using the data.
 
     %h2#standard-reports.heading-medium Standard Report Builder


### PR DESCRIPTION
- Replaces helper-based links with direct URL paths for docs
- Ensures consistency and avoids potential route issues
- Improves clarity of link destinations for users
