### PR TITLE
Hotfix: Release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ including the SPARQL Qonsole
 
 ## Unreleased
 
+## 2.2.2 - 2025-09
+
+- Lock Qonsole-rails gem to v2.1.0 to resolve JSON response issue
+  [85](https://github.com/epimorphics/qonsole-rails/issues/85)
+
 ## 2.2.1 - 2025-08
 
 - Resolved incorrect link to PPD Detailed Documentation

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
-  gem 'qonsole_rails'
+  gem 'qonsole_rails', '=2.1.0'
 end
 
 # TODO: While running the rails app locally for testing you can set gems to your local path

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,18 +103,33 @@ GEM
     erb (5.0.2)
     erubi (1.13.1)
     execjs (2.10.0)
-    faraday (2.13.2)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
+    faraday (1.10.4)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.1)
     faraday-encoding (0.0.6)
       faraday
-    faraday-follow_redirects (0.3.0)
-      faraday (>= 1, < 3)
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
-      faraday (~> 2.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    faraday_middleware (1.2.1)
+      faraday (~> 1.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -197,8 +212,7 @@ GEM
     modernizr-rails (2.7.1)
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
-    net-http (0.6.0)
-      uri
+    multipart-post (2.4.1)
     net-imap (0.5.9)
       date
       net-protocol
@@ -328,6 +342,7 @@ GEM
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -426,11 +441,10 @@ GEM
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0.0)
       sass-rails (~> 6.0)
-    qonsole_rails (2.1.2)
-      faraday (~> 2.13)
+    qonsole_rails (2.1.0)
+      faraday (~> 1.10)
       faraday-encoding (~> 0.0.6)
-      faraday-follow_redirects (~> 0.3.0)
-      faraday-retry (~> 2.0)
+      faraday_middleware (~> 1.2)
       font-awesome-rails (~> 4.7.0)
       haml-rails (~> 2.1)
       jquery-datatables-rails (~> 3.4)
@@ -438,6 +452,9 @@ GEM
       lodash-rails (~> 4.17)
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0)
+      rubocop (~> 1.78)
+      rubocop-ast (~> 1.46)
+      rubocop-rails (~> 2.16)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -462,7 +479,7 @@ DEPENDENCIES
   prometheus-client
   puma
   puma-metrics
-  qonsole_rails!
+  qonsole_rails (= 2.1.0)!
   rails
   rubocop
   rubocop-rails

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 2
-  PATCH = 1
+  PATCH = 2
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
Due to changes in the http client, faraday, the Qonsole data is not being parsed correctly and preventing the qonsole editor to return the expected JSON format response. 

This hotfix locks the Qonsole gem to a working version.

Further investigation will be conducted via ticket [85](https://github.com/epimorphics/qonsole-rails/issues/85)