### PR TITLE
Patch: Update Qonsole-Rails gem to resolve Faraday JSON response issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ including the SPARQL Qonsole
 
 ## Unreleased
 
+## 2.2.2 - 2025-09
+
+- Updated to use latest Qonsole-rails gem, v2.2.1, to resolve JSON response issue
+  [85](https://github.com/epimorphics/qonsole-rails/issues/85)
+
 ## 2.2.1 - 2025-08
 
 - Resolved incorrect link to PPD Detailed Documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     erb (5.0.2)
     erubi (1.13.1)
     execjs (2.10.0)
-    faraday (2.13.2)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -426,7 +426,7 @@ GEM
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0.0)
       sass-rails (~> 6.0)
-    qonsole_rails (2.1.2)
+    qonsole_rails (2.2.1)
       faraday (~> 2.13)
       faraday-encoding (~> 0.0.6)
       faraday-follow_redirects (~> 0.3.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,8 @@
     }
   }
 }
+.qonsole {
+  .query-chrome {
+    label { font-size: 1rem; }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,10 @@
 @import "qonsole_rails/application";
 @import "lr_common_styles/lr-common";
 
+:root {
+  --govuk-font-size-base: 1rem;
+}
+
 .row {
   li,p,dl>dt,dl>dd {
     a {
@@ -12,8 +16,5 @@
     }
   }
 }
-.qonsole {
-  .query-chrome {
-    label { font-size: 1rem; }
-  }
-}
+.qonsole h2,
+.qonsole .query-chrome label { font-size: var(--govuk-font-size-base); }

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 2
-  PATCH = 1
+  PATCH = 2
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This pull request updates the project to version 2.2.2 and includes improvements related to the SPARQL Qonsole integration, style consistency, and dependency management. The most important changes are grouped below.

**Dependency and Version Updates**
* Updated the `Qonsole-rails` gem to v2.2.1 to resolve a JSON response issue, and bumped the project version to 2.2.2 in `app/lib/version.rb`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-0518574840e0c8e03c05369a2f262cf286de4b57955e6408973a1b8bbf7c3effL6-R6)

**Styling Enhancements**
* Introduced a CSS variable for the base font size and applied it to Qonsole headers and labels for consistent sizing in `app/assets/stylesheets/application.scss`.