### PR TITLE
Issue:194-update-rack-to-resolve-vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exception rescue paths were updated to clarify outcomes
 - Error handling and resource logging were improved
 
+### Removed
+
+- Removed deprecated `to_time_preserves_timezone` configuration for Rails 8.1+
+  compatibility
+
 ### Fixed
 
 - Missing status in metrics subscriber was handled to prevent exceptions during

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,12 +39,6 @@ module LrLanding
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # !DEPRECATION WARNING: `to_time` will always preserve the full system
-    # ! timezone offset rather than offset of the receiver in Rails 8.1.
-    # * To opt in to the new behavior and maintain system timezone,
-    # * set the value to :zone; otherwise, set to false
-    config.active_support.to_time_preserves_timezone = :zone
-
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.available_locales = %i[en cy]


### PR DESCRIPTION
refactor: remove deprecated configuration for rails 8.1+

### Removed
- Removed outdated timezone preservation setting to ensure compatibility with newer framework versions

### Docs
- Updated changelog to reflect removal and reasoning

Relates to #194