### PR TITLE
Task: Add initial CuPIT feature tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore Mac system files
+.DS_Store
+
 # Ignore vscode config
 .vscode
 
@@ -54,6 +57,5 @@ tags
 .npmrc
 
 # Ignore local configuration files
-.env
-.env*.local
+.env*
 !.env.development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduced feature tests for branding and home page functionality for use in
+  the Cucumber and Puppetteer Integration Tests (CuPIT).
+- Added a specification file outlining landing page elements which sets up basic
+  scenarios to verify logo presence, page titles and content.
+
+### Changed
+
+- Updated .gitignore rules to include .DS_Store files and prevent unnecessary
+  tracking of Mac OS system files
+- Generalises .env exclusion to cover all variations, except the development one,
+  for better secrets management
+
 ## [2.2.4] - 2025-11
 
 ### Added

--- a/test/features/branding.feature
+++ b/test/features/branding.feature
@@ -1,0 +1,16 @@
+Feature: HMLR Branding
+  As a user
+  I want to see consistent HM Land Registry branding
+  So that I can identify official government data services
+
+  Scenario: Verify logo on home page
+    Given I am a visitor
+    When I open the url "/"
+    Then I expect the attribute "src" from element "img" contain "hm_lr_logo"
+
+  Scenario: Check banner on Elda page
+    Given I am a visitor
+    When I open the url "/anything"
+    Then I expect the element "nav.site" is on the page
+    # TODO: Add style check for background-image containing 'hmg-banner.png'
+    # Requires custom step or inline style attribute check

--- a/test/features/home_page.feature
+++ b/test/features/home_page.feature
@@ -1,0 +1,16 @@
+Feature: Landing Page
+  As a user
+  I want to access the HM Land Registry Open Data landing page
+  So that I can navigate to the various data services
+
+  Scenario: Landing page displays expected content
+    Given I am a visitor
+    When I open the url "/"
+    Then I expect the page title contains "HM Land Registry Open Data"
+    And I expect the element "body" contains text "HM Land Registry Open Data"
+    And I expect the element "link[rel='stylesheet'][href*='application']" is on the page
+    # TODO: Add full validation (that CSS rules exist)
+    # Requires custom step doing all three levels of validation:
+    # 1. Does a stylesheet with this filename pattern exist? (href match) [current last expectation]
+    # 2. Did it load successfully? (cssRules accessible)
+    # 3. Does it contain CSS rules? (cssRules.length > 0)

--- a/test/features/specs/landing.spec
+++ b/test/features/specs/landing.spec
@@ -1,0 +1,52 @@
+# Landing specification
+
+Tags: Landing, root
+
+The landing application holds link to SPARQL console and routes to sub applications
+
+## Page
+
+Tags: Landing
+
+The landing page contains descriptive information about the combined land registry applications
+
+* The page loads with appropriate body content
+* The page contains multiple links to the applications
+* The page contains multiple links to external websites
+
+## Change language
+
+Tags: locale
+
+Users can toggle between English and Welsh language
+
+* Click Cymraeg link in top right
+* Displayed body copy will change to Welsh language
+* Navigation items will be displayed in Welsh language
+* Clicking main navigation title will route user back to home page and language will default to English
+* Click English link in top right
+* All Displayed text will change to English language
+
+## Header
+
+Tags: navigation
+
+Users can navigate to other sub applications from the landing page
+
+* User can see HM Land registry logo and Header
+* 5 primary nav items are visible
+* Clicking 'HM Land registry Open Data' will route users back to landing page
+* Clicking 'UK House Price Index' will route users to the UKHPI app
+* Clicking 'Price Paid Data' will route users to the PPD app
+* Clicking 'Standard-reports' will route users to the standard reports app
+* Clicking 'SPARQL query' will route users to the console query page
+* Clicking logo in top left navigates users to the Gov.uk site relating to the land registry
+* When the browser width is reduced the navigation layout will change
+
+## Navigation
+
+Tags: navigation
+
+* Clicking 'UK House Price Index' will route users to the UKHPI app
+* The primary navigation displays different options relating to UKHPI
+* All other sub-applications retain the navigation structure of the landing page


### PR DESCRIPTION
feat: Adds initial cupit feature tests to enable cucumber and puppeteer integration tests

- Introduces feature tests for branding and home page functionality for use in the cucumber and puppeteer integration tests (cupit).
- Adds a specification file outlining landing page elements which sets up basic scenarios to verify logo presence, page titles and content.

### Additional Changes

- Updates .gitignore rules to include .ds_store files and prevent unnecessary tracking of mac os system files
- Generalises .env exclusion to cover all variations, except the development one, for better secrets management.