### PR TITLE
158 Update Ruby-Sass due to EOL announcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore Mac system files
+.DS_Store
+
 # Ignore vscode config
 .vscode
 
@@ -54,6 +57,5 @@ tags
 .npmrc
 
 # Ignore local configuration files
-.env
-.env*.local
+.env*
 !.env.development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrated from deprecated `sass-rails` gem to `DartSass` for long-term CSS
-  compilation support
+- Migrated from deprecated `sass-rails` gem to `dartsass-sprockets` (Dart Sass)
+  for long-term CSS compilation support
   [#158](https://github.com/epimorphics/lr-landing/issues/158)
-- Added Bootstrap framework dependencies for enhanced styling capabilities and
-  maintainability
+- Removed `bootstrap-sass` in favour of Bootstrap framework dependencies for
+  enhanced styling capabilities and maintainability
 - Updated asset pipeline configuration and loading order for improved
   performance
 - Enabled Autoprefixer source maps for better CSS debugging in development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrated from deprecated `sass-rails` gem to `DartSass` for long-term CSS
+  compilation support
+  [#158](https://github.com/epimorphics/lr-landing/issues/158)
+- Added Bootstrap framework dependencies for enhanced styling capabilities and
+  maintainability
+- Updated asset pipeline configuration and loading order for improved
+  performance
+- Enabled Autoprefixer source maps for better CSS debugging in development
+- Streamlined Rails framework loading configuration
+- Updated Sass configuration for compatibility with new build toolchain
+
 ## [2.2.4] - 2025-11
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -4,35 +4,44 @@ source 'https://rubygems.org'
 
 gem 'rails'
 
-# Use SCSS for stylesheets
-# Use Uglifier as compressor for JavaScript assets
-# gem 'uglifier'
-gem 'terser' # Updating to terser for ES6+ support
+# Use Puma as the app server
+gem 'puma'
 
+
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'get_process_mem'
+# JavaScript asset compressor
+gem 'terser' # Updating to terser for ES6+ support
+
+gem 'autoprefixer-rails'
+gem 'bootstrap', '~> 5.3.2'
+gem 'dartsass-sprockets', '~> 3.2'
+
 gem 'haml-rails'
+
+gem 'get_process_mem'
 gem 'http_accept_language'
-gem 'jbuilder'
 gem 'prometheus-client'
-gem 'puma'
 gem 'puma-metrics'
-gem 'sentry-rails'
+
+# Sentry uses stackprof for performance profiling, has to be loaded before Sentry
+gem 'stackprof'
+gem 'sentry-rails' # rubocop:disable Bundler/OrderedGems
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'dotenv'
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rubocop'
   gem 'rubocop-rails'
 end
 
 group :development do
+  gem 'derailed_benchmarks'
   gem 'ruby-lsp'
   gem 'solargraph'
-  gem 'derailed_benchmarks'
-  gem 'stackprof'
   # Devtools panel for Rails development - loading from the GitHub repo
   # (https://github.com/dejan/rails_panel/issues/209#issuecomment-2621877079_)
   gem 'meta_request', github: 'dejan/rails_panel', ref: 'meta_request-v0.8.5'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gem 'rails'
 
 # Use SCSS for stylesheets
-gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets
 # gem 'uglifier'
 gem 'terser' # Updating to terser for ES6+ support

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'jquery-rails'
 # JavaScript asset compressor
 gem 'terser' # Updating to terser for ES6+ support
 
+# Use SCSS for stylesheets, used mainly in development and test groups
 gem 'autoprefixer-rails'
-gem 'bootstrap', '~> 5.3.2'
 gem 'dartsass-sprockets', '~> 3.2'
 
 gem 'haml-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,12 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console'
+
+  # NOTE: While running the rails app locally for testing you can set gems to your local path
+  # ! These "local" paths do not work with a docker image - use the repo instead
+  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
+  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
+  # gem 'qonsole_rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'
 end
 
 source 'https://rubygems.pkg.github.com/epimorphics' do
@@ -47,9 +53,3 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'lr_common_styles'
   gem 'qonsole_rails'
 end
-
-# TODO: While running the rails app locally for testing you can set gems to your local path
-# ! These "local" paths do not work with a docker image - use the repo instead
-# gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
-# gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
-# gem 'qonsole_rails', path: '~/Epimorphics/clients/land-registry/projects/qonsole-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     benchmark-ips (2.14.0)
     bigdecimal (3.3.1)
     bindex (0.8.1)
+    bootstrap (5.3.5)
+      popper_js (>= 2.11.8, < 3)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -101,6 +103,12 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.0)
     derailed_benchmarks (2.2.1)
       base64
@@ -121,6 +129,7 @@ GEM
       ruby2_keywords
       thor (>= 0.19, < 2)
     diff-lcs (1.6.2)
+    dotenv (3.2.0)
     drb (2.2.3)
     erb (5.1.3)
     erubi (1.13.1)
@@ -152,6 +161,27 @@ GEM
       ffi (~> 1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.33.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     govuk_elements_rails (3.0.2)
       govuk_frontend_toolkit (>= 5.2.0)
       rails (>= 4.1.0)
@@ -259,6 +289,7 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    popper_js (2.11.8)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -362,6 +393,22 @@ GEM
     ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
+    sass-embedded (1.97.1-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -369,6 +416,8 @@ GEM
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -484,8 +533,12 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  autoprefixer-rails
+  bootstrap (~> 5.3.2)
   byebug
+  dartsass-sprockets (~> 3.2)
   derailed_benchmarks
+  dotenv
   get_process_mem
   haml-rails
   http_accept_language

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,6 @@ GEM
     bindex (0.8.1)
     bootstrap (5.3.5)
       popper_js (>= 2.11.8, < 3)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     builder (3.3.0)
     byebug (12.0.0)
     concurrent-ruby (1.3.5)
@@ -134,17 +131,17 @@ GEM
     erb (5.1.3)
     erubi (1.13.1)
     execjs (2.10.0)
-    faraday (2.13.4)
+    faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-encoding (0.0.6)
       faraday
-    faraday-follow_redirects (0.3.0)
+    faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -255,8 +252,8 @@ GEM
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
     mutex_m (0.3.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -496,8 +493,8 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (2.3.1)
-      bootstrap-sass (~> 3.4.1)
+    lr_common_styles (3.0.0)
+      bootstrap (~> 5.3.2)
       font-awesome-rails (~> 4.7.0)
       govuk_elements_rails (= 3.0.2)
       govuk_frontend_toolkit (~> 9.0)
@@ -508,8 +505,7 @@ GEM
       modernizr-rails (~> 2.7)
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0)
-      sass-rails (~> 6.0)
-    qonsole_rails (2.3.0)
+    qonsole_rails (2.4.0)
       faraday (~> 2.13)
       faraday-encoding (~> 0.0, >= 0.0.6)
       faraday-follow_redirects (~> 0.3, >= 0.3.0)
@@ -534,7 +530,6 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
-  bootstrap (~> 5.3.2)
   byebug
   dartsass-sprockets (~> 3.2)
   derailed_benchmarks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   ruby-lsp
-  sass-rails
   sentry-rails
   solargraph
   stackprof

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 .PHONY:	assets auth check clean image lint publish realclean run tag test vars
 
-ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.22
-AWS_REGION?=eu-west-1
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
+RUBY_VERSION?=$(shell cat .ruby-version)
+ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
+AWS_REGION?=eu-west-1
 ECR?=${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3000
-RUBY_VERSION?=$(shell cat .ruby-version)
+
 SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 STAGE?=dev
 API_SERVICE_URL?=http://localhost:8888
@@ -24,9 +25,9 @@ TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
-GITHUB_TOKEN=.github-token
 BUNDLE_CFG=.bundle/config
 BUNDLE=./bin/bundle
+GITHUB_TOKEN=.github-token
 RAILS=./bin/rails
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
@@ -35,20 +36,25 @@ ${BUNDLE_CFG}: ${GITHUB_TOKEN}
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
 
-all: image
+all: image ## Default target: build the Docker image
 
-assets:
-	@echo "Installing bundled gems ..."
+assets: bundles compiled ## Compile assets for serving
+	@echo assets completed.
+
+auth: ${GITHUB_TOKEN} ${BUNDLE_CFG} ## Set up authentication for GitHub and Bundler
+	@echo "Authentication set up for GitHub and Bundler."
+
+bundles: ## Install Ruby gems via Bundler
+	@echo "Installing Ruby gems via Bundler..."
 	@${BUNDLE} install
-	@echo "Cleaning and precompiling static assets ..."
-	@${BUNDLE} exec rake assets:clean assets:precompile
 
-auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
-
-check: lint test
+check: checks ## Alias for `checks` target
 	@echo "All checks passed."
 
-clean:
+checks: lint test ## Run all checks: linting and tests
+	@echo "All checks passed."
+
+clean: ## Clean up temporary and compiled files
 	@echo "Cleaning up ${SHORTNAME} files..."
 # Clean up the project
 	@[ -d public/assets ] && ${RAILS} assets:clobber || :
@@ -57,7 +63,21 @@ clean:
 # Remove temporary files and directories
 	@@ rm -rf bundle coverage log node_modules tmp
 
-image: auth
+compiled: ## Compile assets for production
+	@echo "Removing old compiled assets and compiling ..."
+	@${RAILS} assets:clobber assets:precompile
+
+forceclean: realclean ## Remove all bundled files
+	@${BUNDLE} clean --force || :
+
+help: ## Display this message
+	@echo "Available make targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Environment variables (optional: all variables have defaults):"
+	@make vars
+
+image: auth ## Build the Docker image
 	@echo Building ${REPO}:${TAG} ...
 	@docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -73,47 +93,53 @@ image: auth
 		.
 	@echo Done.
 
-forceclean: realclean
-# Remove all bundled files
-	@${BUNDLE} clean --force || :
+lint: rubocop ## Run linting checks
+	@echo "All linting complete."
 
-lint: assets
-	@${BUNDLE} exec rubocop
+local: ## Run the application locally
+	@echo "Running ${SHORTNAME} locally pointing to ${API_SERVICE_URL} API ..."
+	@API_SERVICE_URL=${API_SERVICE_URL} bin/dev -p ${PORT}
 
-name:
+name: ## Display the shortname of the application
 	@echo ${SHORTNAME}
 
-publish: image
+publish: image ## Publish the Docker image to the registry
 	@echo Publishing image: ${REPO}:${TAG} ...
 	@docker push ${REPO}:${TAG} 2>&1
 	@echo Done.
 
-realclean: clean
+realclean: clean ## Remove all generated files and authentication
 	@echo "Removing authentication from ${SHORTNAME}..."
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
-run: start
+rubocop: ## Run RuboCop linting
+	@echo "Running RuboCop linting for ${SHORTNAME} ..."
+# Auto-correct offenses safely where possible with the `-a` flag
+	@${BUNDLE} exec rubocop -a
+
+run: start ## Run the Docker container locally
 	@if docker network inspect dnet > /dev/null 2>&1; then echo "Using docker network dnet"; else echo "Create docker network dnet"; docker network create dnet; sleep 2; fi
 	@docker run ${RUN_VARS} ${PORT}:3000 --env API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
-server: start
+server: start ## Run the Rails server locally
 	@API_SERVICE_URL=${API_SERVICE_URL} ${RAILS} server -p ${PORT}
 
-start: stop
+start: stop ## Start the application
 	@echo "Starting ${SHORTNAME} pointing to ${API_SERVICE_URL} API ..."
 
-stop:
+stop: ## Stop the application
 	@echo "Stopping ${SHORTNAME} ..."
 	@docker stop ${SHORTNAME} > /dev/null 2>&1 || :
 
-tag:
+tag: ## Display the Docker image tag
 	@echo ${TAG}
 
-test: assets
-	@echo "Running tests ..."
+test: ## Run unit tests
+	@echo "Running unit tests ..."
+# Run Rails tests
 	@${RAILS} test
 
-vars:
+vars: ## Display environment variables
 	@echo "Docker: ${REPO}:${TAG}"
 	@echo "ACCOUNT = ${ACCOUNT}"
 	@echo "ALPINE_VERSION = ${ALPINE_VERSION}"
@@ -130,5 +156,5 @@ vars:
 	@echo "TAG = ${TAG}"
 	@echo "VERSION = ${VERSION}"
 
-version:
+version: ## Display the application version
 	@echo ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets auth check clean image lint publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint publish realclean run tag test update vars
 
 ALPINE_VERSION?=3.22
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
@@ -138,6 +138,15 @@ test: ## Run unit tests
 	@echo "Running unit tests ..."
 # Run Rails tests
 	@${RAILS} test
+
+update: ## Review and update dependencies interactively
+	@echo "Checking for outdated dependencies..."
+	@if command -v yarn &> /dev/null; then \
+		echo "Running yarn upgrade-interactive..."; \
+		yarn upgrade-interactive; \
+	fi
+	@echo "Running bundle outdated to check Ruby gems..."
+	@bundle outdated
 
 vars: ## Display environment variables
 	@echo "Docker: ${REPO}:${TAG}"

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,36 @@
+# TODO
+
+## Pre-Integration Tasks
+
+- [x] Run `bundle install` to update Gemfile.lock after removing `popper_js`
+- [x] Verify local testing with lr_common_styles via local path works correctly
+- [x] Run `make check` (or equivalent) to verify linting and tests pass
+- [x] Test asset compilation with `rails assets:precompile`
+- [x] Verify Bootstrap dropdowns and popovers function correctly
+- [x] Check browser console for JavaScript errors related to Popper/Bootstrap
+- [x] Verify local testing with qonsole_rails via local path works correctly
+- [x] Test SPARQL query functionality (empty results, non-empty results)
+- [x] Verify dropdown components display and function correctly in query interface
+- [x] Check query form responsiveness on mobile and desktop viewports
+
+## Integration Tasks
+
+- [x] Update Gemfile to use published lr_common_styles 3.0.0 from eGPR
+- [x] Run `bundle update lr_common_styles` to lock new version
+- [x] Remove local path override from Gemfile
+- [x] Test full application functionality with published gem
+- [x] Update Gemfile to use published qonsole_rails 2.4.0 from eGPR
+- [x] Run `bundle update qonsole_rails` to lock new version
+- [x] Remove local path override from Gemfile
+- [x] Test full application functionality with published qonsole_rails gem
+
+## Deployment Tasks
+
+- [ ] Deploy to test/staging environment
+- [ ] Verify UI components render correctly
+- [ ] Test interactive Bootstrap components (modals, dropdowns, tooltips)
+- [ ] Monitor for asset pipeline errors in logs
+- [ ] Test query submission and result handling (including empty results)
+- [ ] Verify query form responsiveness and dropdown toggles work correctly
+- [ ] Monitor logs for deprecation warnings and response noise
+- [ ] Deploy to production after successful testing

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,12 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+
+// Favicon assets now managed via the asset pipeline.
+//= link favicon/apple-touch-icon.png
+//= link favicon/favicon-32x32.png
+//= link favicon/favicon-16x16.png
+//= link favicon/manifest.json
+//= link favicon/safari-pinned-tab.svg
+//= link favicon/favicon.ico
+//= link favicon/browserconfig.xml

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,18 +10,13 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+// Load dependencies first (libraries, gems, engines) before custom application code.
 //= require jquery
 //= require jquery_ujs
-//= require_tree .
 //= require lodash
 //= require qonsole_rails/application
 //= require lr_common_styles/application
-
-// LR Common Styles specific
-//= link favicon/apple-touch-icon.png
-//= link favicon/favicon-32x32.png
-//= link favicon/favicon-16x16.png
-//= link favicon/manifest.json
-//= link favicon/safari-pinned-tab.svg
-//= link favicon/favicon.ico
-//= link favicon/browserconfig.xml
+//
+// Load custom application code last to ensure all dependencies are available.
+// IMPORTANT: Keep require_tree at the end to avoid loading order issues.
+//= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,8 @@
 // Load dependencies first (libraries, gems, engines) before custom application code.
 //= require jquery
 //= require jquery_ujs
+//= require popper
+//= require bootstrap
 //= require lodash
 //= require qonsole_rails/application
 //= require lr_common_styles/application

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,20 +1,8 @@
 @import "govuk-template";
 @import "govuk-elements";
-@import "bootstrap-sprockets";
 @import "bootstrap";
+@import "font-awesome";
 @import "qonsole_rails/application";
 @import "lr_common_styles/lr-common";
-
-:root {
-  --govuk-font-size-base: 1rem;
-}
-
-.row {
-  li,p,dl>dt,dl>dd {
-    a {
-      text-decoration: underline;
-    }
-  }
-}
-.qonsole h2,
-.qonsole .query-chrome label { font-size: var(--govuk-font-size-base); }
+@import "landing";
+@import "qonsole";

--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -1,0 +1,48 @@
+:root {
+  --govuk-font-size-base: 1rem;
+}
+
+.row {
+
+  li,
+  p,
+  dl>dt,
+  dl>dd {
+    a {
+      text-decoration: underline;
+    }
+  }
+}
+
+.cookie-banner {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: initial;
+  padding-inline: 3rem;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+
+.o-container {
+  max-width: 960px;
+  margin-inline: auto;
+}
+
+
+@media (min-width: 768px) {
+  .dl-horizontal {
+    dt {
+      float: left;
+      width: 160px;
+      clear: left;
+      text-align: right;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    dd {
+      margin-left: 180px;
+    }
+
+  }
+}

--- a/app/assets/stylesheets/qonsole.scss
+++ b/app/assets/stylesheets/qonsole.scss
@@ -1,0 +1,237 @@
+:root {
+  --govuk-font-size-base: 1.0rem;
+  --qonsole-font-size-base: calc(var(--govuk-font-size-base) + 0.4rem);
+  --qonsole-bg-opacity: 0.25;
+  --qonsole-button-padding-vertical: 0.6rem;
+  --qonsole-button-padding-horizontal: 1.2rem;
+  --qonsole-button-base-colour: #fff;
+  --qonsole-button-border-colour: #ddd;
+  --qonsole-button-active-colour: #337ab7;
+  --qonsole-button-disabled-colour: #777777;
+}
+
+.qonsole {
+
+  h2,
+  label {
+    font-size: var(--govuk-font-size-base);
+  }
+
+  .btn {
+    font-size: var(--qonsole-font-size-base);
+    padding: var(--qonsole-button-padding-vertical) var(--qonsole-button-padding-horizontal);
+  }
+
+  .well {
+    min-height: 20px;
+    padding: 5px;
+    margin-bottom: 20px;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 4px;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+
+    &.vertical {
+      @media (min-width: 576px) {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+    }
+  }
+
+  .query-chrome {
+    // Override bootstrap container padding
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+
+    .row {
+
+      &:first-of-type {
+        @media (min-width: 44em) {
+          justify-content: space-between;
+        }
+      }
+
+      .form-group {
+        margin-bottom: 1rem; // Overrides form-group margin-bottom
+        text-align: start;
+        align-self: flex-end;
+        @media (min-width: 576px) {
+          text-align: end;
+          &:first-of-type {
+            text-align: start;
+          }
+        }
+      }
+
+      [role="menuitem"] {
+        display: inline-block;
+        font-size: var(--qonsole-font-size-base);
+        white-space: nowrap;
+        padding: var(--qonsole-button-padding-vertical) var(--qonsole-button-padding-horizontal);
+        width: 100%;
+      }
+    }
+
+    label {
+      font-size: var(--govuk-font-size-base);
+    }
+  }
+
+  .list-inline {
+    >li {
+      display: inline-block;
+      padding-right: 5px;
+      padding-left: 5px;
+
+      label {
+        display: inline-flex;
+        gap: 0 1rem;
+        max-width: 100%;
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .bg-danger {
+    background-color: rgba(var(--bs-danger-rgb), var(--qonsole-bg-opacity)) !important;
+  }
+
+  &.form-inline {
+
+    @media (min-width: 768px) {
+
+      .radio,
+      .checkbox {
+        display: inline-block;
+        margin-top: 0;
+        margin-bottom: 0;
+        vertical-align: middle;
+      }
+    }
+
+    .form-control {
+      display: inline-block;
+      font-size: var(--qonsole-font-size-base);
+      width: auto;
+
+      &:not(.input-sm) {
+        height: 34px;
+        padding: 0.6rem 1.2rem;
+        vertical-align: middle;
+      }
+    }
+
+    :is(select.form-control.input-sm) {
+      appearance: auto;
+      font-size: var(--qonsole-font-size-base);
+
+      option {
+        font-size: var(--qonsole-font-size-base);
+      }
+    }
+  }
+
+  #results {
+
+    // Massiver override for the bottom of the results panel due to paginnation overflow
+    .row {
+      &:last-of-type {
+
+        .col-sm-5,
+        .col-sm-7 {
+          width: 100% !important
+        }
+      }
+    }
+
+    .bg-danger {
+      padding: 1rem;
+    }
+
+    .pagination {
+      display: inline-flex;
+      flex-wrap: nowrap;
+      justify-content: baseline;
+      align-items: center;
+      padding-left: 0;
+      margin: 0;
+      border-radius: 4px;
+
+      li {
+        padding: 1em !important;
+
+        a,
+        span {
+          position: relative;
+          display: inline-block;
+          padding: var(--qonsole-button-padding-vertical) var(--qonsole-button-padding-horizontal);
+          line-height: 1.428571429;
+          margin-left: -1px;
+          color: var(--qonsole-button-active-colour);
+          text-decoration: none;
+          background-color: var(--qonsole-button-base-colour);
+          border: 1px solid var(--qonsole-button-border-colour);
+        }
+
+        &:hover,
+        &:focus {
+
+          a,
+          span {
+            z-index: 2;
+            color: var(--qonsole-button-active-colour);
+            background-color: #eee;
+            border-color: var(--qonsole-button-border-colour);
+          }
+        }
+
+        &:first-child {
+
+          a,
+          span {
+            margin-inline-start: 0;
+            padding-inline-start: 24px;
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+          }
+        }
+
+        &:last-child {
+
+          a,
+          span {
+            padding-inline-end: 24px;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+          }
+        }
+
+        &.disabled {
+
+          a,
+          span {
+            color: var(--qonsole-button-disabled-colour);
+            cursor: not-allowed;
+            background-color: var(--qonsole-button-base-colour);
+            border-color: #ddd;
+          }
+        }
+
+        &.active {
+
+          a,
+          span {
+            color: var(--qonsole-button-base-colour);
+            cursor: default;
+            background-color: var(--qonsole-button-active-colour);
+            border-color: var(--qonsole-button-active-colour);
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/doc/accessibility.html.haml
+++ b/app/views/doc/accessibility.html.haml
@@ -1,4 +1,9 @@
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-= render partial: 'shared/lang_switch'
-= render partial: "accessibility_#{I18n.locale}"
+.row
+  .col-md-12
+    = render partial: 'shared/lang_switch'
+
+.row
+  .col-md-12
+    = render partial: "accessibility_#{I18n.locale}"

--- a/app/views/doc/privacy.html.haml
+++ b/app/views/doc/privacy.html.haml
@@ -1,4 +1,9 @@
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-= render partial: 'shared/lang_switch'
-= render partial: "privacy_#{I18n.locale}"
+.row
+  .col-md-12
+    = render partial: 'shared/lang_switch'
+
+.row
+  .col-md-12
+    = render partial: "privacy_#{I18n.locale}"

--- a/app/views/exceptions/error_page.html.haml
+++ b/app/views/exceptions/error_page.html.haml
@@ -2,7 +2,7 @@
 - puts "View state: #{@view_state.inspect}" if Rails.env.development?
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-.row
+.row.mx-3.my-5
   .col-md-12
     %article.u-clear
       - if status == 400

--- a/app/views/exceptions/error_page.html.haml
+++ b/app/views/exceptions/error_page.html.haml
@@ -2,65 +2,67 @@
 - puts "View state: #{@view_state.inspect}" if Rails.env.development?
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-%article.u-clear
-  - if status == 400
-    %h1.o-heading--1 Request not understood
-    %p
-      We're sorry, but the request you made was not understood. If you are requesting
-      data via a script or program, please check the URL parameters. If you see this
-      message as a result of using the HPI or PPD applications, please let us
-      know so that we can correct the problem.
+.row
+  .col-md-12
+    %article.u-clear
+      - if status == 400
+        %h1.o-heading--1 Request not understood
+        %p
+          We're sorry, but the request you made was not understood. If you are requesting
+          data via a script or program, please check the URL parameters. If you see this
+          message as a result of using the HPI or PPD applications, please let us
+          know so that we can correct the problem.
 
-  - elsif status == 403
-    %h1.o-heading--1 Request denied
+      - elsif status == 403
+        %h1.o-heading--1 Request denied
 
-    %p
-      We're sorry, but the request you made was not permitted. If you are requesting
-      data via a script or program, please check the URL parameters. If you see this
-      message as a result of using the HPI or PPD applications, please let us know so
-      that we can correct the problem.
+        %p
+          We're sorry, but the request you made was not permitted. If you are requesting
+          data via a script or program, please check the URL parameters. If you see this
+          message as a result of using the HPI or PPD applications, please let us know so
+          that we can correct the problem.
 
-  - elsif status == 404
-    %h1.o-heading--1 Page not found
+      - elsif status == 404
+        %h1.o-heading--1 Page not found
 
-    %p
-      We're sorry, but the web page you requested is not present on our server.
-      Please check the spelling of the page address (URL). If you require further
-      assistance, please see the contact details below.
+        %p
+          We're sorry, but the web page you requested is not present on our server.
+          Please check the spelling of the page address (URL). If you require further
+          assistance, please see the contact details below.
 
-  - elsif status == 422
-    %h1.o-heading--1 The change you wanted was rejected.
+      - elsif status == 422
+        %h1.o-heading--1 The change you wanted was rejected.
 
-    %p
-      Maybe you tried to change something you didn't have access to? If you are
-      the application owner, check the logs for more information.
+        %p
+          Maybe you tried to change something you didn't have access to? If you are
+          the application owner, check the logs for more information.
 
-  - else
-    %h1.o-heading--1 Application error
+      - else
+        %h1.o-heading--1 Application error
 
-    %p
-      We're very sorry, but the request you just made resulted in an internal
-      error in the UKHPI application. If this problem persists, please use one of the contact
-      methods below to report the problem to us so that we can resolve it and
-      help you get the data you require.
+        %p
+          We're very sorry, but the request you just made resulted in an internal
+          error in the UKHPI application. If this problem persists, please use one of the contact
+          methods below to report the problem to us so that we can resolve it and
+          help you get the data you require.
 
-  - if sentry_code
-    %h2.o-heading--3 Reference code
-    %p
-      If you need to contact support staff about this issue, please use the following
-      code to identify the problem:
-      %code
-        = sentry_code
+      - if sentry_code
+        %h2.o-heading--3 Reference code
+        %p
+          If you need to contact support staff about this issue, please use the following
+          code to identify the problem:
+          %code
+            = sentry_code
 
-  %h2.o-heading--2 Who to contact
-  %ul.list.list-bullet
-    %li
-      If you are unable to access the data, please
-      %a{ href: '//site.landregistry.gov.uk/contact-us/form' }
-        fill in our contact form.
-    %li
-      For general transaction data enquiries, email
-      = mail_to('DRO@landregistry.gov.uk')
-    %li
-      For general price paid data enquiries, contact
-      = mail_to(Rails.application.config.contact_email_address)
+      %h2.o-heading--2 Who to contact
+      %ul.list.list-bullet
+        %li
+          If you are unable to access the data, please
+          %a{ href: '//site.landregistry.gov.uk/contact-us/form' }
+            fill in our contact form.
+        %li
+          For general transaction data enquiries, email
+          = mail_to('DRO@landregistry.gov.uk')
+        %li
+          For general price paid data enquiries, contact
+          = mail_to(Rails.application.config.contact_email_address)

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -1,167 +1,166 @@
 - content_for(:title, 'Data Agored')
-.row
-  .col-md-12
-    %h1.heading-large
-      = yield(:title)
 
-    %p
-      Mae Cofrestrfa Tir EM yn cyhoeddi’r setiau data cyhoeddus canlynol fel
-      rhan o’n hymrwymiad i flaenoriaethau’r Llywodraeth i dwf economaidd
-      a thryloywder data:
-    %ul.list.list-bullet
-      %li
-        = link_to('Data Pris a Dalwyd', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Esboniad o Ddata Pris a Dalwyd')
-        sy’n cael ei ddiweddaru’n fisol, gyda data ar gael o 1995.
-      %li
-        = link_to('Data Trafodiad', 'https://www.gov.uk/land-registry-transaction-data', 'aria-label' => 'Mynediad at ddata trafodion')
-        sy’n cael ei ddiweddaru’n fisol, gyda data ar gael o Ragfyr 2011.
-      %li
-        = link_to('Lawrlwythiadau Mynegai Prisiau Tai y DU', 'https://www.gov.uk/government/collections/mynegai-prisiau-tai-y-du-adroddiadau.cy', 'aria-label' => 'Lawrlwythiadau Mynegai Prisiau Tai y DU')
-        sy’n cael eu diweddaru’n fisol, gyda data ar gael o Ionawr 1995.
-        %br
-        Mae Cofrestrfa Tir EM yn cyhoeddi
-        = link_to('Mynegai Prisiau Tai y DU', '/app/ukhpi?lang=cy', 'aria-label' => 'Archwilio Mynegai Prisiau Tai y DU')
-        ar ran y Swyddfa Ystadegau Gwladol, Cofrestri’r Alban a Gwasanaethau
-        Tir ac Eiddo Gogledd Iwerddon.
+%h1.heading-large
+  = yield(:title)
 
-    %p
-      Darperir y setiau data ar ffurf
-      = link_to('gwerthoedd wedi’u gwahanu ag atalnod', 'http://en.wikipedia.org/wiki/Comma-separated_values', 'aria-label' => "Esboniad Wikipedia o werthoedd wedi’u gwahanu ag atalnod (csv)")
-      a
-      = link_to('data cysylltiedig', 'http://en.wikipedia.org/wiki/Linked_data', 'aria-label' => 'Esboniad Wikipedia o ddata cysylltiedig')
-      gyda Data Pris a Dalwyd ar gael ar ffurf testun hefyd.
-      Gellir lawrlwytho’r setiau data hyn yn llawn trwy fynd i’n
-      = succeed "." do
-        = link_to('Data Cyhoeddus', 'https://www.gov.uk/government/publications/land-registry-data', 'aria-label' => 'trosolwg o Ddata Cyhoeddus CTEM')
+%p
+  Mae Cofrestrfa Tir EM yn cyhoeddi’r setiau data cyhoeddus canlynol fel
+  rhan o’n hymrwymiad i flaenoriaethau’r Llywodraeth i dwf economaidd
+  a thryloywder data:
+%ul.list.list-bullet
+  %li
+    = link_to('Data Pris a Dalwyd', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Esboniad o Ddata Pris a Dalwyd')
+    sy’n cael ei ddiweddaru’n fisol, gyda data ar gael o 1995.
+  %li
+    = link_to('Data Trafodiad', 'https://www.gov.uk/land-registry-transaction-data', 'aria-label' => 'Mynediad at ddata trafodion')
+    sy’n cael ei ddiweddaru’n fisol, gyda data ar gael o Ragfyr 2011.
+  %li
+    = link_to('Lawrlwythiadau Mynegai Prisiau Tai y DU', 'https://www.gov.uk/government/collections/mynegai-prisiau-tai-y-du-adroddiadau.cy', 'aria-label' => 'Lawrlwythiadau Mynegai Prisiau Tai y DU')
+    sy’n cael eu diweddaru’n fisol, gyda data ar gael o Ionawr 1995.
+    %br
+    Mae Cofrestrfa Tir EM yn cyhoeddi
+    = link_to('Mynegai Prisiau Tai y DU', '/app/ukhpi?lang=cy', 'aria-label' => 'Archwilio Mynegai Prisiau Tai y DU')
+    ar ran y Swyddfa Ystadegau Gwladol, Cofrestri’r Alban a Gwasanaethau
+    Tir ac Eiddo Gogledd Iwerddon.
 
-    %h2.heading-large Adroddiadau pwrpasol
-    %p
-      Gall cwsmeriaid Pris a Dalwyd a’r Mynegai Prisiau Tai nad ydynt am gael y
-      set ddata lawn greu adroddiadau pwrpasol gyda’r teclynnau canlynol:
-    %ul.list.list-bullet
-      %li
-        Chwilio
-        = link_to( 'mynegai prisiau tai y DU', '#ukhpi', 'aria-label' => 'sut i ddod o hyd i Fynegai Prisiau Tai y DU')
-      %li
-        Lluniwr
-        = link_to('adroddiad data pris a dalwyd', '#ppd', 'aria-label' => 'sut i greu adroddiad data pris a dalwyd')
-      %li
-        Lluniwr
-        = link_to('adroddiad data pris a dalwyd safonol ', '#standard-reports', 'aria-label' => 'sut i greu adroddiad data pris a dalwyd safonol')
+%p
+  Darperir y setiau data ar ffurf
+  = link_to('gwerthoedd wedi’u gwahanu ag atalnod', 'http://en.wikipedia.org/wiki/Comma-separated_values', 'aria-label' => "Esboniad Wikipedia o werthoedd wedi’u gwahanu ag atalnod (csv)")
+  a
+  = link_to('data cysylltiedig', 'http://en.wikipedia.org/wiki/Linked_data', 'aria-label' => 'Esboniad Wikipedia o ddata cysylltiedig')
+  gyda Data Pris a Dalwyd ar gael ar ffurf testun hefyd.
+  Gellir lawrlwytho’r setiau data hyn yn llawn trwy fynd i’n
+  = succeed "." do
+    = link_to('Data Cyhoeddus', 'https://www.gov.uk/government/publications/land-registry-data', 'aria-label' => 'trosolwg o Ddata Cyhoeddus CTEM')
 
-    %h2#ukhpi.heading-medium Chwilio Mynegai Prisiau Tai y DU
-    %p
-      Defnyddiwch
-      = link_to('declyn chwilio mynegai prisiau tai y DU', '/app/ukhpi?lang=cy', 'aria-label' => 'Archwilio Mynegai Prisiau Tai y DU')
-      i ganfod is-set benodol o’r data mynegai mae gennych ddiddordeb ynddo, ac yna ei lawrlwytho.
-      Gellir dadansoddi adroddiadau yn ôl gwledydd, rhanbarthau, siroedd neu awdurdodau lleol
-      dros gyfnod penodol o amser sy’n dyddio’n ôl i Ionawr 1995. Gellir eu teilwra ymhellach
-      i amrywiaeth o ddewisiadau adrodd gan gynnwys dangosyddion, categorïau eiddo neu nifer gwerthiannau.
-    %p
-      Gwybodaeth bellach: darllenwch ragor am
-      = succeed "," do
-        = link_to('am Chwilio mynegai prisiau tai y DU', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/4873585#chwilio-mynegai-prisiau-tai-y-du')
-      neu am
-      = succeed "." do
-        = link_to('ddata mynegai prisiau tai y DU', '/app/ukhpi/doc?lang=cy')
+%h2.heading-large Adroddiadau pwrpasol
+%p
+  Gall cwsmeriaid Pris a Dalwyd a’r Mynegai Prisiau Tai nad ydynt am gael y
+  set ddata lawn greu adroddiadau pwrpasol gyda’r teclynnau canlynol:
+%ul.list.list-bullet
+  %li
+    Chwilio
+    = link_to( 'mynegai prisiau tai y DU', '#ukhpi', 'aria-label' => 'sut i ddod o hyd i Fynegai Prisiau Tai y DU')
+  %li
+    Lluniwr
+    = link_to('adroddiad data pris a dalwyd', '#ppd', 'aria-label' => 'sut i greu adroddiad data pris a dalwyd')
+  %li
+    Lluniwr
+    = link_to('adroddiad data pris a dalwyd safonol ', '#standard-reports', 'aria-label' => 'sut i greu adroddiad data pris a dalwyd safonol')
 
-    %h2#ppd.heading-medium Lluniwr Adroddiad Data Pris a Dalwyd
-    %p
-      Defnyddiwch
-      = link_to('Adroddiadau Data Pris a Dalwyd', '/app/ppd', 'aria-label' => 'archwilio data pris a dalwyd')
-      i greu adroddiadau pwrpasol gan ddefnyddio ein Data Pris a Dalwyd. Gellir
-      seilio adroddiadau ar leoliad, daliadaeth, pris a dalwyd neu fath o eiddo
-      dros gyfnod penodol.
-    %p
-      Mae ein Data Pris a Dalwyd yn olrhain gwerthiannau eiddo preswyl yng
-      Nghymru a Lloegr a gyflwynir inni i’w cofrestru. Mae’r set ddata’n
-      ffynhonnell ddibynadwy o wybodaeth am brisiau tai ac mae’n cynnwys dros
-      24 miliwn o gofnodion yn dyddio’n ôl i Ionawr 1995. I gael rhagor o
-      wybodaeth am y set ddata hon a’r hyn mae’n ei gynnwys a’r hyn
-      nad yw’n ei chynnwys, darllenwch
-      = succeed "." do
-        = link_to('Data am y Pris a Dalwyd', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Esboniad o Ddata Pris a Dalwyd')
-    %p
-      Rydym yn ceisio sicrhau bod ein data cyhoeddus mor gywir â phosibl, ond
-      ni allwn warantu na fydd yn cynnwys gwallau neu’n addas at eich dibenion
-      neu eich defnydd. Mae adroddiadau’n seiliedig ar ddata a gasglwyd ar yr
-      adeg y cofrestrwyd y trafodiad eiddo gyda ni ac ni fydd o reidrwydd yn
-      gyfredol o ran y wybodaeth fwyaf diweddar. Darllenwch
-      = link_to('pa mor gywir yw’r data?', 'https://www.gov.uk/government/publications/land-registry-data/public-data#accuracy-of-the-data')
-      am ragor o wybodaeth.
+%h2#ukhpi.heading-medium Chwilio Mynegai Prisiau Tai y DU
+%p
+  Defnyddiwch
+  = link_to('declyn chwilio mynegai prisiau tai y DU', '/app/ukhpi?lang=cy', 'aria-label' => 'Archwilio Mynegai Prisiau Tai y DU')
+  i ganfod is-set benodol o’r data mynegai mae gennych ddiddordeb ynddo, ac yna ei lawrlwytho.
+  Gellir dadansoddi adroddiadau yn ôl gwledydd, rhanbarthau, siroedd neu awdurdodau lleol
+  dros gyfnod penodol o amser sy’n dyddio’n ôl i Ionawr 1995. Gellir eu teilwra ymhellach
+  i amrywiaeth o ddewisiadau adrodd gan gynnwys dangosyddion, categorïau eiddo neu nifer gwerthiannau.
+%p
+  Gwybodaeth bellach: darllenwch ragor am
+  = succeed "," do
+    = link_to('am Chwilio mynegai prisiau tai y DU', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/4873585#chwilio-mynegai-prisiau-tai-y-du')
+  neu am
+  = succeed "." do
+    = link_to('ddata mynegai prisiau tai y DU', '/app/ukhpi/doc?lang=cy')
 
-    %h3.heading-small Gwybodaeth bellach
-    %ul.list.list-bullet
-      %li
-        = link_to('dogfennaeth fanwl', '/app/doc/ppd', 'aria-label' => 'dogfennaeth fanwl ar gyfer Lluniwr Adroddiad Data Pris a Dalwyd')
-        am y Data Pris a Dalwyd, y model data, a defnyddio’r data.
+%h2#ppd.heading-medium Lluniwr Adroddiad Data Pris a Dalwyd
+%p
+  Defnyddiwch
+  = link_to('Adroddiadau Data Pris a Dalwyd', '/app/ppd', 'aria-label' => 'archwilio data pris a dalwyd')
+  i greu adroddiadau pwrpasol gan ddefnyddio ein Data Pris a Dalwyd. Gellir
+  seilio adroddiadau ar leoliad, daliadaeth, pris a dalwyd neu fath o eiddo
+  dros gyfnod penodol.
+%p
+  Mae ein Data Pris a Dalwyd yn olrhain gwerthiannau eiddo preswyl yng
+  Nghymru a Lloegr a gyflwynir inni i’w cofrestru. Mae’r set ddata’n
+  ffynhonnell ddibynadwy o wybodaeth am brisiau tai ac mae’n cynnwys dros
+  24 miliwn o gofnodion yn dyddio’n ôl i Ionawr 1995. I gael rhagor o
+  wybodaeth am y set ddata hon a’r hyn mae’n ei gynnwys a’r hyn
+  nad yw’n ei chynnwys, darllenwch
+  = succeed "." do
+    = link_to('Data am y Pris a Dalwyd', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Esboniad o Ddata Pris a Dalwyd')
+%p
+  Rydym yn ceisio sicrhau bod ein data cyhoeddus mor gywir â phosibl, ond
+  ni allwn warantu na fydd yn cynnwys gwallau neu’n addas at eich dibenion
+  neu eich defnydd. Mae adroddiadau’n seiliedig ar ddata a gasglwyd ar yr
+  adeg y cofrestrwyd y trafodiad eiddo gyda ni ac ni fydd o reidrwydd yn
+  gyfredol o ran y wybodaeth fwyaf diweddar. Darllenwch
+  = link_to('pa mor gywir yw’r data?', 'https://www.gov.uk/government/publications/land-registry-data/public-data#accuracy-of-the-data')
+  am ragor o wybodaeth.
 
-    %h2#standard-reports.heading-medium Lluniwr Adroddiad Safonol
-    %p
-      Darperir y
-      = link_to('Lluniwr Adroddiad Safonol', '/app/standard-reports', 'aria-label' => "defnyddio’r Lluniwr Adroddiad Safonol")
-      gan ddefnyddio’n Data Pris a Dalwyd. Defnyddiwch y teclyn hwn i greu
-      adroddiadau pwrpasol sy’n ddata prisiau cyfanredol. Mae’r gwasanaeth
-      hwn yn eich caniatáu i ffurfweddu adroddiad ar gyfer gwahanol ardaloedd
-      daearyddol yng Nghymru a Lloegr, o lefel sir i sectorau cod post dros
-      gyfnod penodol o amser.
+%h3.heading-small Gwybodaeth bellach
+%ul.list.list-bullet
+  %li
+    = link_to('dogfennaeth fanwl', '/app/doc/ppd', 'aria-label' => 'dogfennaeth fanwl ar gyfer Lluniwr Adroddiad Data Pris a Dalwyd')
+    am y Data Pris a Dalwyd, y model data, a defnyddio’r data.
 
-    %h2.heading-large#linked-data Data cysylltiedig
-    %p
-      Rydym yn cyhoeddi’r data hwn ar ffurf data cysylltiedig hefyd, gan anelu at
-      = link_to('sgôr pum seren', 'http://5stardata.info/en/')
-    %p
-      Os hoffech roi cynnig ar eich ymholiadau SPARQL eich hunan yn erbyn ein
-      cyhoeddiadau data cysylltiedig, defnyddiwch
-      = succeed "." do
-        = link_to('y ffurflen SPARQL hon', qonsole_rails_path, 'aria-label' => 'defnyddio golygydd ymholiadau SPARQL')
-    %p
-      Os hoffech weld yr ymholiad SPARQL a ddefnyddir i greu’r adroddiadau
-      yn y teclynnau adrodd Mynegai Prisiau Tai a Data Pris a Dalwyd a
-      ddisgrifir uchod, gallwch wneud hyn trwy ddewis y camau ‘view SPARQL query’
-      o olwg ‘download data’ ym mhob teclyn chwilio. Mae modd diwygio
-      ac ail-redeg yr ymholiad SPARQL yn ôl yr angen hyd yn oed.
-    %p
-      Y setiau data cysylltiedig:
-    %dl.dl-horizontal
-      %dt
-        = link_to('Data pris a dalwyd', '/data/ppi/transaction-record', 'aria-label' => 'mynediad at gofnodion trafodion Data Pris a Dalwyd')
-      %dd
-        set ddata cysylltiedig 4★
-        sy’n cynnwys dros 400 miliwn o driawdau.
-        Darllenwch y
-        = succeed "." do
-          = link_to('diffiniadau data ar gyfer y set ddata Data Trafodion', '/def/ppi')
-      %dt
-        = link_to('Data Trafodiad', '/data/trans/applications', 'aria-label' => 'mynediad at drafodion ceisiadau')
-      %dd
-        set ddata cysylltiedig 4★
-        Darllenwch y
-        = succeed "." do
-          = link_to('diffiniadau data ar gyfer set ddata Data Trafodiad', '/def/trans', 'aria-label' => 'diffiniadau data ar gyfer y set ddata trafodion')
-      %dt
-        = link_to('Mynegai Prisiau Tai Y DU', '/data/ukhpi' , 'aria-label' => 'set ddata data cysylltiedig Mynegai Prisiau Tai y DU')
-      %dd
-        set ddata cysylltiedig 5★
-        Darllenwch y
-        = succeed "." do
-          = link_to('diffiniadau data ar gyfer set ddata Mynegai Prisiau Tai y DU', '/def/ukhpi', 'aria-label' => 'diffiniadau data ar gyfer set ddata Mynegai Prisiau Tai y DU')
+%h2#standard-reports.heading-medium Lluniwr Adroddiad Safonol
+%p
+  Darperir y
+  = link_to('Lluniwr Adroddiad Safonol', '/app/standard-reports', 'aria-label' => "defnyddio’r Lluniwr Adroddiad Safonol")
+  gan ddefnyddio’n Data Pris a Dalwyd. Defnyddiwch y teclyn hwn i greu
+  adroddiadau pwrpasol sy’n ddata prisiau cyfanredol. Mae’r gwasanaeth
+  hwn yn eich caniatáu i ffurfweddu adroddiad ar gyfer gwahanol ardaloedd
+  daearyddol yng Nghymru a Lloegr, o lefel sir i sectorau cod post dros
+  gyfnod penodol o amser.
 
-    %h2.heading-large#contact-us
-      Â phwy i gysylltu
-    %p
-      Os oes angen cymorth arnoch i gael mynediad at y data,
-      = succeed "." do
-        = link_to('defnyddiwch ein ffurflen gysylltu', 'https://customerhelp.landregistry.gov.uk/welshcontactuswebform/')
-    %p
-      Ar gyfer ymholiadau’n ymwneud â’r Mynegai Prisiau Tai, gweler
-      = succeed "." do
-        = link_to('Am y Mynegai Prisiau Tai – Cysylltu', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/4873585#cysylltu')
+%h2.heading-large#linked-data Data cysylltiedig
+%p
+  Rydym yn cyhoeddi’r data hwn ar ffurf data cysylltiedig hefyd, gan anelu at
+  = link_to('sgôr pum seren', 'http://5stardata.info/en/')
+%p
+  Os hoffech roi cynnig ar eich ymholiadau SPARQL eich hunan yn erbyn ein
+  cyhoeddiadau data cysylltiedig, defnyddiwch
+  = succeed "." do
+    = link_to('y ffurflen SPARQL hon', qonsole_rails_path, 'aria-label' => 'defnyddio golygydd ymholiadau SPARQL')
+%p
+  Os hoffech weld yr ymholiad SPARQL a ddefnyddir i greu’r adroddiadau
+  yn y teclynnau adrodd Mynegai Prisiau Tai a Data Pris a Dalwyd a
+  ddisgrifir uchod, gallwch wneud hyn trwy ddewis y camau ‘view SPARQL query’
+  o olwg ‘download data’ ym mhob teclyn chwilio. Mae modd diwygio
+  ac ail-redeg yr ymholiad SPARQL yn ôl yr angen hyd yn oed.
+%p
+  Y setiau data cysylltiedig:
+%dl.dl-horizontal
+  %dt
+    = link_to('Data pris a dalwyd', '/data/ppi/transaction-record', 'aria-label' => 'mynediad at gofnodion trafodion Data Pris a Dalwyd')
+  %dd
+    set ddata cysylltiedig 4★
+    sy’n cynnwys dros 400 miliwn o driawdau.
+    Darllenwch y
+    = succeed "." do
+      = link_to('diffiniadau data ar gyfer y set ddata Data Trafodion', '/def/ppi')
+  %dt
+    = link_to('Data Trafodiad', '/data/trans/applications', 'aria-label' => 'mynediad at drafodion ceisiadau')
+  %dd
+    set ddata cysylltiedig 4★
+    Darllenwch y
+    = succeed "." do
+      = link_to('diffiniadau data ar gyfer set ddata Data Trafodiad', '/def/trans', 'aria-label' => 'diffiniadau data ar gyfer y set ddata trafodion')
+  %dt
+    = link_to('Mynegai Prisiau Tai Y DU', '/data/ukhpi' , 'aria-label' => 'set ddata data cysylltiedig Mynegai Prisiau Tai y DU')
+  %dd
+    set ddata cysylltiedig 5★
+    Darllenwch y
+    = succeed "." do
+      = link_to('diffiniadau data ar gyfer set ddata Mynegai Prisiau Tai y DU', '/def/ukhpi', 'aria-label' => 'diffiniadau data ar gyfer set ddata Mynegai Prisiau Tai y DU')
 
-    %p
-      Ar gyfer ymholiadau’n ymwneud â data trafodiad, anfonwch ebost at
-      = mail_to('DRO@landregistry.gov.uk')
-    %p
-      Ar gyfer ymholiadau cyffredinol yn ymwneud â Data Pris a Dalwyd, cysylltwch â
-      = succeed "." do
-        = mail_to(Rails.application.config.contact_email_address)
+%h2.heading-large#contact-us
+  Â phwy i gysylltu
+%p
+  Os oes angen cymorth arnoch i gael mynediad at y data,
+  = succeed "." do
+    = link_to('defnyddiwch ein ffurflen gysylltu', 'https://customerhelp.landregistry.gov.uk/welshcontactuswebform/')
+%p
+  Ar gyfer ymholiadau’n ymwneud â’r Mynegai Prisiau Tai, gweler
+  = succeed "." do
+    = link_to('Am y Mynegai Prisiau Tai – Cysylltu', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/4873585#cysylltu')
+
+%p
+  Ar gyfer ymholiadau’n ymwneud â data trafodiad, anfonwch ebost at
+  = mail_to('DRO@landregistry.gov.uk')
+%p
+  Ar gyfer ymholiadau cyffredinol yn ymwneud â Data Pris a Dalwyd, cysylltwch â
+  = succeed "." do
+    = mail_to(Rails.application.config.contact_email_address)

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -1,166 +1,166 @@
 - content_for(:title, 'Open Data')
-.row
-  .col-md-12
-    %h1.heading-large
-      = yield(:title)
-    %p
-      HM Land Registry publishes the following public datasets on GOV.UK
-      as part of our commitment to the Government’s priorities
-      of economic growth and data transparency:
-    %ul.list.list-bullet
-      %li
-        = link_to('Price Paid Data', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Explanation of Price Paid Data')
-        updated monthly, data available from 1995.
-      %li
-        = link_to('Transaction data', 'https://www.gov.uk/land-registry-transaction-data', 'aria-label' => 'Access transaction data')
-        updated monthly, data available from December 2011.
-      %li
-        = link_to('UK House Price Index downloads', 'https://www.gov.uk/government/collections/uk-house-price-index-reports#about-the-uk-hpi', 'aria-label' => 'UK House Price Index downloads')
-        updated monthly, data available from January 1995.
-        %br
-        HM Land Registry publish the
-        = link_to('UK House Price Index', '/app/ukhpi', 'aria-label' => 'Explore the UK house price index')
-        on behalf of Office for National Statistics, Registers of Scotland and
-        Land and Property Services Northern Ireland.
 
-    %p
-      These datasets are provided in
-      = link_to('comma-separated value (csv)', 'http://en.wikipedia.org/wiki/Comma-separated_values', 'aria-label' => 'wikipedia explanation of comma-separated value (csv)')
-      and
-      = link_to('linked data', 'http://en.wikipedia.org/wiki/Linked_data', 'aria-label' => 'Wikipedia explanation of linked data')
-      formats, with Price Paid Data also
-      available as a text file. These datasets can be downloaded in full by accessing our
-      = succeed "." do
-        = link_to('Public Data', 'https://www.gov.uk/government/publications/land-registry-data', 'aria-label' => 'overview of HMLR Public Data')
+%h1.heading-large
+  = yield(:title)
 
-    %h2.heading-large Bespoke reports
-    %p
-      Price Paid Data and House Price Index customers who do not require
-      the full dataset can run bespoke reports with the following tools:
-    %ul.list.list-bullet
-      %li
-        Search the
-        = link_to( 'UK house price index', '#ukhpi', 'aria-label' => 'how to find the UK house price index')
-      %li
-        Build a
-        = link_to('price paid data report', '#ppd', 'aria-label' => 'how to create a price-paid data report')
-      %li
-        Build a
-        = link_to('standard price paid data report', '#standard-reports', 'aria-label' => 'how to create a standard price-paid data report')
+%p
+  HM Land Registry publishes the following public datasets on GOV.UK
+  as part of our commitment to the Government’s priorities
+  of economic growth and data transparency:
+%ul.list.list-bullet
+  %li
+    = link_to('Price Paid Data', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Explanation of Price Paid Data')
+    updated monthly, data available from 1995.
+  %li
+    = link_to('Transaction data', 'https://www.gov.uk/land-registry-transaction-data', 'aria-label' => 'Access transaction data')
+    updated monthly, data available from December 2011.
+  %li
+    = link_to('UK House Price Index downloads', 'https://www.gov.uk/government/collections/uk-house-price-index-reports#about-the-uk-hpi', 'aria-label' => 'UK House Price Index downloads')
+    updated monthly, data available from January 1995.
+    %br
+    HM Land Registry publish the
+    = link_to('UK House Price Index', '/app/ukhpi', 'aria-label' => 'Explore the UK house price index')
+    on behalf of Office for National Statistics, Registers of Scotland and
+    Land and Property Services Northern Ireland.
 
-    %h2#ukhpi.heading-medium Search the UK House Price Index
-    %p
-      Use the
-      = link_to('UK house price index search tool', '/app/ukhpi', 'aria-label' => 'Explore the UK house price index')
-      to identify a specific subset of the index data you’re interested in, and then download it.
-      Reports can be broken down by countries, regions, counties or local authorities over a
-      defined period of time dating back to January 1995. They can then be further tailored to
-      a variety of reporting options including indicators, property categories or sales volumes.
-    %p
-      Further information: read more about
-      = succeed "," do
-        = link_to('searching the UKHPI', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/about-the-uk-house-price-index#searching-the-uk-house-price-index')
-      or more
-      = succeed "." do
-        = link_to('details about the UKHPI data', '/app/ukhpi/doc')
+%p
+  These datasets are provided in
+  = link_to('comma-separated value (csv)', 'http://en.wikipedia.org/wiki/Comma-separated_values', 'aria-label' => 'wikipedia explanation of comma-separated value (csv)')
+  and
+  = link_to('linked data', 'http://en.wikipedia.org/wiki/Linked_data', 'aria-label' => 'Wikipedia explanation of linked data')
+  formats, with Price Paid Data also
+  available as a text file. These datasets can be downloaded in full by accessing our
+  = succeed "." do
+    = link_to('Public Data', 'https://www.gov.uk/government/publications/land-registry-data', 'aria-label' => 'overview of HMLR Public Data')
 
-    %h2#ppd.heading-medium Price Paid Data Report Builder
-    %p
-      Use
-      = link_to('Price Paid Data Reports', '/app/ppd', 'aria-label' => 'explore price-paid data')
-      to build bespoke reports using our detailed Price Paid Data. Reports
-      can be based on location, tenure, price paid or property type over a
-      defined period of time.
-    %p
-      Our Price Paid Data tracks the residential property sales in
-      England and Wales that are lodged with us for registration. The
-      dataset is a reliable source of house price information and
-      consists of more than 24 million definitive records dating back
-      to January 1995. For more information on this dataset and
-      what it does and doesn't include, read
-      = succeed "." do
-        = link_to('about the Price Paid Data', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Explanation of Price Paid Data')
-    %p
-      We strive to ensure that our public data is as accurate as possible
-      but cannot guarantee that it is free from errors or fit for your
-      purpose or use. Reports are based on data collected at the time a
-      property transaction is registered with us and will not necessarily
-      be up to date with the most recent information. Read
-      = link_to('how accurate is the data?', 'https://www.gov.uk/government/publications/land-registry-data/public-data#accuracy-of-the-data')
-      for more information.
+%h2.heading-large Bespoke reports
+%p
+  Price Paid Data and House Price Index customers who do not require
+  the full dataset can run bespoke reports with the following tools:
+%ul.list.list-bullet
+  %li
+    Search the
+    = link_to( 'UK house price index', '#ukhpi', 'aria-label' => 'how to find the UK house price index')
+  %li
+    Build a
+    = link_to('price paid data report', '#ppd', 'aria-label' => 'how to create a price-paid data report')
+  %li
+    Build a
+    = link_to('standard price paid data report', '#standard-reports', 'aria-label' => 'how to create a standard price-paid data report')
 
-    %h3.heading-small Further information
-    %ul.list.list-bullet
-      %li
-        = link_to('detailed documentation', '/app/doc/ppd', 'aria-label' => 'detailed documentation for the Price Paid Data Report Builder')
-        about the Price Paid Data, the data model, and using the data.
+%h2#ukhpi.heading-medium Search the UK House Price Index
+%p
+  Use the
+  = link_to('UK house price index search tool', '/app/ukhpi', 'aria-label' => 'Explore the UK house price index')
+  to identify a specific subset of the index data you’re interested in, and then download it.
+  Reports can be broken down by countries, regions, counties or local authorities over a
+  defined period of time dating back to January 1995. They can then be further tailored to
+  a variety of reporting options including indicators, property categories or sales volumes.
+%p
+  Further information: read more about
+  = succeed "," do
+    = link_to('searching the UKHPI', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/about-the-uk-house-price-index#searching-the-uk-house-price-index')
+  or more
+  = succeed "." do
+    = link_to('details about the UKHPI data', '/app/ukhpi/doc')
 
-    %h2#standard-reports.heading-medium Standard Report Builder
-    %p
-      The
-      = link_to('Standard Report Builder', '/app/standard-reports', 'aria-label' => 'use the Standard Report Builder')
-      is provided
-      using our Price Paid Data. Use this tool to build bespoke
-      reports that are aggregated price data. This service allows
-      you to configure a report for various geographical areas in
-      England and Wales, from the country level down to postcode sectors over a defined period of time.
+%h2#ppd.heading-medium Price Paid Data Report Builder
+%p
+  Use
+  = link_to('Price Paid Data Reports', '/app/ppd', 'aria-label' => 'explore price-paid data')
+  to build bespoke reports using our detailed Price Paid Data. Reports
+  can be based on location, tenure, price paid or property type over a
+  defined period of time.
+%p
+  Our Price Paid Data tracks the residential property sales in
+  England and Wales that are lodged with us for registration. The
+  dataset is a reliable source of house price information and
+  consists of more than 24 million definitive records dating back
+  to January 1995. For more information on this dataset and
+  what it does and doesn't include, read
+  = succeed "." do
+    = link_to('about the Price Paid Data', 'https://www.gov.uk/about-the-price-paid-data', 'aria-label' => 'Explanation of Price Paid Data')
+%p
+  We strive to ensure that our public data is as accurate as possible
+  but cannot guarantee that it is free from errors or fit for your
+  purpose or use. Reports are based on data collected at the time a
+  property transaction is registered with us and will not necessarily
+  be up to date with the most recent information. Read
+  = link_to('how accurate is the data?', 'https://www.gov.uk/government/publications/land-registry-data/public-data#accuracy-of-the-data')
+  for more information.
 
-    %h2.heading-large#linked-data Linked Data
-    %p
-      We also publish this data in linked data format, aiming for
-      = link_to('five star rating', 'http://5stardata.info/en/')
-    %p
-      If you would like to try out your own SPARQL queries against our
-      linked data publications,  use
-      = succeed "." do
-        = link_to('the SPARQL form', qonsole_rails_path, 'aria-label' => 'use the SPARQL query editor')
-    %p
-      If you want to see the SPARQL query that is used to generate the reports in the
-      HPI and PPD reporting tools described above, you can do this by selecting the
-      'view SPARQL query' actions from the 'download data'
-      view in each search tool.
-      You can even amend and re-run the SPARQL query as required.
-    %p
-      The linked-data datasets:
-    %dl.dl-horizontal
-      %dt
-        = link_to('Price Paid Data', '/data/ppi/transaction-record', 'aria-label' => 'access to Price Paid Data transaction records')
-      %dd
-        4★ linked dataset containing over
-        400 million triples.
-        Read the
-        = succeed "." do
-          = link_to('data definitions for the PPD dataset', '/def/ppi')
-      %dt
-        = link_to('Transaction Data', '/data/trans/applications', 'aria-label' => 'access to application transactions')
-      %dd
-        4★ linked dataset.
-        Read the
-        = succeed "." do
-          = link_to('data definitions for the transactions dataset', '/def/trans', 'aria-label' => 'data definitions for the transactions dataset')
-      %dt
-        = link_to('UKHPI', '/data/ukhpi' , 'aria-label' => 'the UKHPI linked-data dataset')
-      %dd
-        5★ linked dataset.
-        Read the
-        = succeed "." do
-          = link_to('data definitions for the UK HPI dataset', '/def/ukhpi', 'aria-label' => 'data definitions for the UK HPI dataset')
+%h3.heading-small Further information
+%ul.list.list-bullet
+  %li
+    = link_to('detailed documentation', '/app/doc/ppd', 'aria-label' => 'detailed documentation for the Price Paid Data Report Builder')
+    about the Price Paid Data, the data model, and using the data.
 
-    %h2.heading-large#contact-us
-      Who to contact
-    %p
-      If you need help to access the data, please
-      = succeed "." do
-        = link_to('use our contact form', 'https://customerhelp.landregistry.gov.uk/guide-page-external/?stepid=2b31bc48-eb96-eb11-b1ac-002248413956')
-    %p
-      For UK House Price Index enquiries please see
-      = succeed "." do
-        = link_to('About the House Price Index - Contacts', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/about-the-uk-house-price-index#contact')
+%h2#standard-reports.heading-medium Standard Report Builder
+%p
+  The
+  = link_to('Standard Report Builder', '/app/standard-reports', 'aria-label' => 'use the Standard Report Builder')
+  is provided
+  using our Price Paid Data. Use this tool to build bespoke
+  reports that are aggregated price data. This service allows
+  you to configure a report for various geographical areas in
+  England and Wales, from the country level down to postcode sectors over a defined period of time.
 
-    %p
-      For general transaction data enquiries email
-      = mail_to('DRO@landregistry.gov.uk')
-    %p
-      For general Price Paid Data enquiries contact
-      = succeed "." do
-        = mail_to(Rails.application.config.contact_email_address)
+%h2.heading-large#linked-data Linked Data
+%p
+  We also publish this data in linked data format, aiming for
+  = link_to('five star rating', 'http://5stardata.info/en/')
+%p
+  If you would like to try out your own SPARQL queries against our
+  linked data publications,  use
+  = succeed "." do
+    = link_to('the SPARQL form', qonsole_rails_path, 'aria-label' => 'use the SPARQL query editor')
+%p
+  If you want to see the SPARQL query that is used to generate the reports in the
+  HPI and PPD reporting tools described above, you can do this by selecting the
+  'view SPARQL query' actions from the 'download data'
+  view in each search tool.
+  You can even amend and re-run the SPARQL query as required.
+%p
+  The linked-data datasets:
+%dl.dl-horizontal
+  %dt
+    = link_to('Price Paid Data', '/data/ppi/transaction-record', 'aria-label' => 'access to Price Paid Data transaction records')
+  %dd
+    4★ linked dataset containing over
+    400 million triples.
+    Read the
+    = succeed "." do
+      = link_to('data definitions for the PPD dataset', '/def/ppi')
+  %dt
+    = link_to('Transaction Data', '/data/trans/applications', 'aria-label' => 'access to application transactions')
+  %dd
+    4★ linked dataset.
+    Read the
+    = succeed "." do
+      = link_to('data definitions for the transactions dataset', '/def/trans', 'aria-label' => 'data definitions for the transactions dataset')
+  %dt
+    = link_to('UKHPI', '/data/ukhpi' , 'aria-label' => 'the UKHPI linked-data dataset')
+  %dd
+    5★ linked dataset.
+    Read the
+    = succeed "." do
+      = link_to('data definitions for the UK HPI dataset', '/def/ukhpi', 'aria-label' => 'data definitions for the UK HPI dataset')
+
+%h2.heading-large#contact-us
+  Who to contact
+%p
+  If you need help to access the data, please
+  = succeed "." do
+    = link_to('use our contact form', 'https://customerhelp.landregistry.gov.uk/guide-page-external/?stepid=2b31bc48-eb96-eb11-b1ac-002248413956')
+%p
+  For UK House Price Index enquiries please see
+  = succeed "." do
+    = link_to('About the House Price Index - Contacts', 'https://www.gov.uk/government/publications/about-the-uk-house-price-index/about-the-uk-house-price-index#contact')
+
+%p
+  For general transaction data enquiries email
+  = mail_to('DRO@landregistry.gov.uk')
+%p
+  For general Price Paid Data enquiries contact
+  = succeed "." do
+    = mail_to(Rails.application.config.contact_email_address)

--- a/app/views/landing/index.html.haml
+++ b/app/views/landing/index.html.haml
@@ -1,4 +1,9 @@
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-= render partial: 'shared/lang_switch'
-= render partial: "index_#{I18n.locale}"
+.row
+  .col-sm-12
+    = render partial: 'shared/lang_switch'
+
+.row
+  .col-md-12
+    = render partial: "index_#{I18n.locale}"

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,20 +47,23 @@ module LrLanding
   end
 end
 
-# Monkey-patch the bit of Rails that emits the start-up log message, so that it
-# is written out in JSON format that our combined logging service can handle
+# Monkey-patch the bit of Rails that emits the start-up log message, so
+# that it is written out in JSON format that our combined logging
+# service can handle
 module Rails
   # :nodoc:
   module Command
     # :nodoc:
     class ServerCommand
       def print_boot_information(server, url)
-        msg = {
+        msg = "Starting #{server} Rails #{Rails.version} in #{Rails.env}"
+        msg += " on #{url}" if url
+        info = {
           ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
           level: 'INFO',
-          message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+          message: msg
         }
-        say msg.to_json
+        say info.to_json
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,9 @@ module LrLanding
 
     # Quiet SASS deprecation warnings coming from dependencies
     config.sass.quiet_deps = true
+    # Silence @import deprecation warnings during migration to @use/@forward
+    # See: https://sass-lang.com/d/import
+    config.sass.silence_deprecations = ['import']
   end
 end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,9 @@ module LrLanding
     config.i18n.available_locales = %i[en cy]
     config.i18n.default_locale = :en
     config.i18n.enforce_available_locales = true
+
+    # Quiet SASS deprecation warnings coming from dependencies
+    config.sass.quiet_deps = true
   end
 end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,19 +2,15 @@
 
 require File.expand_path('boot', __dir__)
 
-require 'rails'
 # Pick the frameworks you want:
-require 'active_model/railtie'
-# require "active_job/railtie"
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
-require 'action_view/railtie'
 require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+Bundler.require(:default, Rails.env)
 
 require 'qonsole_rails'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,8 +38,8 @@ Rails.application.configure do
   # Don't print a log message every time an asset file is loaded
   config.assets.quiet = true
 
-  # Set the log level to the value of the LOG_LEVEL environment variable, or 'debug' if not set
-  config.log_level = ENV.fetch('LOG_LEVEL', 'debug').to_sym
+  # Enable SASS source maps in development for easier debugging
+  config.sass.inline_source_maps = true
   # Tag rails logs with useful information
   config.log_tags = %i[subdomain request_id request_method]
   # When sync mode is true, all output is immediately flushed to the underlying
@@ -47,6 +47,8 @@ Rails.application.configure do
   $stdout.sync = true
   # Log the stdout output to the Epimorphics JSON logging gem
   config.logger = JsonRailsLogger::Logger.new($stdout)
+  # Set the log level to the value of the LOG_LEVEL environment variable, or 'debug' by default
+  config.log_level = ENV.fetch('LOG_LEVEL', 'debug').to_sym
 
   # By default Rails expects that your application is running at the root (e.g. /).
   # This configuration sets running your application inside a directory.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,11 @@ Rails.application.configure do
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
+  # `config.sass.style` has been deprecated in favor of `config.assets.css_compressor`
+  # Set SASS output style to compressed for smaller file sizes
+  config.sass.style = :compressed
+  # SASS source maps are disabled in production for performance
+  config.sass.inline_source_maps = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to
   # config/initializers/assets.rb
@@ -87,9 +92,10 @@ Rails.application.configure do
   # compiled asset paths
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
 
-  # API location can be specified in the environment
-  # But defaults to the dev service
-  # API location is not used on the landing page, but is required by all other apps
+  # API_SERVICE_URL should also be specified in the entrypoint.sh file and
+  # set in the Makefile as an env variable for the docker container when run as an image.
+  # API_SERVICE_URL is not used on the landing page, but is required by all other apps
+  # config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
 
   # Set the log level to the value of the LOG_LEVEL environment variable, or 'info' if not set
   config.log_level = ENV.fetch('LOG_LEVEL', 'info').to_sym

--- a/config/initializers/autoprefixer.rb
+++ b/config/initializers/autoprefixer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Configure Autoprefixer to generate source maps for easier debugging of CSS
+# See: https://github.com/tablecheck/dartsass-sprockets/issues/23#issuecomment-2408131105
+class AutoprefixerWithSourcemap < AutoprefixerRails::Sprockets
+  def self.run(filename, css)
+    output = "#{filename.chomp(File.extname(filename))}.css"
+
+    # If you want this nice an generic, you could check `css` for the presence
+    # of an inline source map, and set the `map` argument based on that
+    # instead of always setting it to `true`.
+    result = @processor.process(css, from: filename, to: output, map: true)
+
+    result.warnings.each do |warning|
+      warn "autoprefixer: #{warning}"
+    end
+
+    result.css
+  end
+
+  def self.use_bundle_processor?
+    ::Sprockets::VERSION.to_f >= 4
+  end
+
+  def self.install(env)
+    if use_bundle_processor?
+      env.register_bundle_processor('text/css', self)
+    else
+      env.register_postprocessor('text/css', self)
+    end
+  end
+
+  def self.uninstall(env)
+    if use_bundle_processor?
+      env.unregister_bundle_processor('text/css', self)
+    else
+      env.unregister_postprocessor('text/css', self)
+    end
+  end
+end
+
+Rails.application.config.assets.configure do |env|
+  AutoprefixerRails.uninstall(env)
+  AutoprefixerWithSourcemap.register_processor(AutoprefixerRails.processor({}))
+  AutoprefixerWithSourcemap.install(env)
+end


### PR DESCRIPTION
## Summary

Modernised asset pipeline and CSS tooling by migrating from deprecated `sass-rails` gem to Dart Sass via `dartsass-sprockets`, whilst integrating Bootstrap framework dependencies for enhanced styling capabilities and improved maintainability.

Specific to ticket [#158](https://github.com/epimorphics/lr-landing/issues/158)

## Changes

- Migrated from deprecated `sass-rails` gem to `dartsass-sprockets` (Dart Sass) for long-term CSS compilation support
- Removed `bootstrap-sass` in favour of Bootstrap framework dependencies for enhanced styling capabilities and maintainability
- Updated asset pipeline configuration and loading order for improved performance
- Enabled `Autoprefixer` source maps for better CSS debugging in development
- Streamlined Rails framework loading configuration
- Updated Sass configuration for compatibility with new build toolchain

## Breaking Changes

None

## Checklist

### Testing
- [ ] ~~Unit tests added/updated~~
- [x] Manual testing completed
- [x] No regressions introduced

### Build & Assets
- [x] Assets compile successfully in build step
- [x] Sass/CSS build chain functioning correctly
- [x] Remote gem loading verified locally
- [x] Linting passes (rubocop, eslint)

### Process & Quality
- [x] Changelog updated
- [ ] ~~Documentation updated~~