### PR TITLE
Task: Release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-02
+
 ### Added
 
 - Added test coverage reporting with SimpleCov and a `coverage` Makefile target.

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 3
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end

--- a/app/views/exceptions/error_page.html.haml
+++ b/app/views/exceptions/error_page.html.haml
@@ -11,7 +11,7 @@
           We're sorry, but the request you made was not understood. If you are requesting
           data via a script or program, please check the URL parameters. If you see this
           message as a result of using the House Price Index or Price Paid Data applications,
-          please let usknow so that we can correct the problem.
+          please let us know so that we can correct the problem.
 
       - elsif status == 403
         %h1.o-heading--1 Request denied
@@ -19,7 +19,7 @@
         %p
           We're sorry, but the request you made was not permitted. If you are requesting
           data via a script or program, please check the URL parameters. If you see this
-          message as a result of using the HPI or PPD applications, please let us know so
+          message as a result of using the House Price Index or Price Paid Data applications, please let us know so
           that we can correct the problem.
 
       - elsif status == 404


### PR DESCRIPTION
Prepared the 2.3.1 patch release by updating the version, adding release notes, and fixing user-facing error page wording for clarity and consistency.

## What's changed:
- Bumped application version to 2.3.1 for a patch release
- Corrected error page text and expanded product names in messages
- Documented the 2.3.1 release notes in the changelog