### PR TITLE
docs(doc): remove resolved accessibility issues from statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed resolved accessibility issues from statement.
+  [#162](https://github.com/epimorphics/hmlr-linked-data/issues/162)
 - Replaced layout tables on the PPD and HPI doc pages with accessible
   markup: definition lists for label/value pairs, and proper `<th>`
   header cells and `<caption>` elements for genuine tabular data.

--- a/app/views/doc/_accessibility_cy.html.haml
+++ b/app/views/doc/_accessibility_cy.html.haml
@@ -58,22 +58,9 @@
       ar sgriniau llai. Gall hyn arwain at golli gwybodaeth neu swyddogaeth, nad yw&#8217;n bodloni&#8217;r canllaw hygyrchedd ar
       gyfer ail-lifo cynnwys.
     %li
-      1.4.11 Cyferbyniad Di-destun (Lefel AA)
-      %br
-      Nid oes gan y botwm perfformio ymholiad gymhareb gyferbyniad ddigonol rhwng cefndir y botwm a&#8217;r testun.
-    %li
-      1.4.12: Bylchu Testun (Lefel AA)
-      %br
-      Mae rhai penawdau H2 yn rhy fach yn ddiofyn, a allai hefyd effeithio ar y gymhareb gyferbyniad, gan arwain at
-      problemau darllenadwyedd i rai defnyddwyr y mae angen bylchu testun wedi ei addasu arnynt.
-    %li
       2.1.2 Dim Trap Bysellfwrdd (Lefel A)
       %br
       Ni all defnyddwyr fynd heibio&#8217;r prif faes testun gan ddefnyddio&#8217;r allwedd tab yn unig.
-    %li
-      2.4.2: Teitlau Tudalen (Lefel A)
-      %br
-      Mae angen teitl mwy disgrifiadol i egluro pwrpas tudalen ffurflen SPARQL.
     %li
       4.1.2: Enw, Rôl, Gwerth (Lefel A)
       %br

--- a/app/views/doc/_accessibility_en.html.haml
+++ b/app/views/doc/_accessibility_en.html.haml
@@ -56,22 +56,9 @@
       especially at smaller screen sizes. This may result in a loss of information or functionality,
       which does not meet the accessibility guideline for content reflow.
     %li
-      1.4.11 Non-text Contrast (Level AA)
-      %br
-      The perform query button has an insufficient contrast ratio between the button background and text.
-    %li
-      1.4.12: Text Spacing (Level AA)
-      %br
-      Some H2 headings are too small by default, which could also impact the contrast ratio,
-      leading to readability issues for some users who need adjusted text spacing.
-    %li
       2.1.2 No Keyboard Trap (Level A)
       %br
       Users cannot progress past the code editor panel using the tab key alone.
-    %li
-      2.4.2: Page Titles (Level A)
-      %br
-      A more descriptive title (and H1 tag) is needed to clarify the purpose of the SPARQL form page.
     %li
       4.1.2: Name, Role, Value (Level A)
       %br


### PR DESCRIPTION
Removed the following resolved accessibility issues from the statement:

- 1.4.11 Non-text Contrast (Level AA) the perform query button has an insufficient contrast ratio between the button background and text.
- 1.4.12: Text Spacing (Level AA) Some H2 headings are too small by default, which could also impact the contrast ratio, leading to readability issues for some users who need adjusted text spacing.
- 2.4.2: Page Titles (Level A)
- A more descriptive title (and H1 tag) is needed to clarify the purpose of the SPARQL form page.

Relates to this ticket - https://github.com/epimorphics/hmlr-linked-data/issues/162